### PR TITLE
Use default value instead of Logical OR

### DIFF
--- a/www.daangnpay.com/src/components/Header.tsx
+++ b/www.daangnpay.com/src/components/Header.tsx
@@ -8,7 +8,7 @@ interface Props {
   alt?: string;
 }
 
-const Header: FC<Props> = ({ image_data, alt }) => {
+const Header: FC<Props> = ({ image_data, alt = "" }) => {
   const image = image_data && getImage(image_data);
 
   const onLinkClick = () => {
@@ -19,7 +19,7 @@ const Header: FC<Props> = ({ image_data, alt }) => {
     <Wrapper>
       <Box>
         <Logo>
-          <GatsbyImage image={image} alt={alt || ""} />
+          <GatsbyImage image={image} alt={alt} />
           <LogoText>당근페이</LogoText>
         </Logo>
 


### PR DESCRIPTION
이미지의 대체 텍스트가 없을 경우에는 `alt`속성의 빈 문자열을 대입하고 있습니다.
`<Header />`컴포넌트의 `alt`의 타입이 `alt?: string`이므로, 주어지지 않았을 경우 빈 문자열을 기본값으로 사용한다는 것을 더 드러내고 싶어서 Logical OR operator를 사용하는 것보다, 기본값을 할당하는 방법으로 명시하는 것으로 수정해보았습니다.

See also
  - https://ko.javascript.info/destructuring-assignment#ref-1939