### PR TITLE
global 웹페이지 asset CDN prefix 를 환경에서 주입할 수 있도록 변경

### DIFF
--- a/ca.karrotmarket.com/gatsby-config.js
+++ b/ca.karrotmarket.com/gatsby-config.js
@@ -7,6 +7,9 @@ const siteMetadata = {
 };
 
 module.exports = {
+  ...(process.env.ASSET_PREFIX && {
+    assetPrefix: process.env.ASSET_PREFIX,
+  }),
   flags: {
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,

--- a/ca.karrotmarket.com/package.json
+++ b/ca.karrotmarket.com/package.json
@@ -8,7 +8,7 @@
     "directory": "ca.karrotmarket.com"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop"
   },

--- a/jp.karrotmarket.com/gatsby-config.js
+++ b/jp.karrotmarket.com/gatsby-config.js
@@ -6,6 +6,9 @@ const siteMetadata = {
 };
 
 module.exports = {
+  ...(process.env.ASSET_PREFIX && {
+    assetPrefix: process.env.ASSET_PREFIX,
+  }),
   flags: {
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,

--- a/jp.karrotmarket.com/package.json
+++ b/jp.karrotmarket.com/package.json
@@ -8,7 +8,7 @@
     "directory": "jp.karrotmarket.com"
   },
   "scripts": {
-    "build": "gatsby build && rsync -av --delete public/ public/xxx",
+    "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
     "serve": "gatsby serve"

--- a/uk.karrotmarket.com/gatsby-config.js
+++ b/uk.karrotmarket.com/gatsby-config.js
@@ -7,6 +7,9 @@ const siteMetadata = {
 };
 
 module.exports = {
+  ...(process.env.ASSET_PREFIX && {
+    assetPrefix: process.env.ASSET_PREFIX,
+  }),
   flags: {
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,

--- a/uk.karrotmarket.com/package.json
+++ b/uk.karrotmarket.com/package.json
@@ -8,7 +8,7 @@
     "directory": "uk.karrotmarket.com"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop"
   },

--- a/us.karrotmarket.com/gatsby-config.js
+++ b/us.karrotmarket.com/gatsby-config.js
@@ -7,6 +7,9 @@ const siteMetadata = {
 };
 
 module.exports = {
+  ...(process.env.ASSET_PREFIX && {
+    assetPrefix: process.env.ASSET_PREFIX,
+  }),
   flags: {
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,

--- a/us.karrotmarket.com/package.json
+++ b/us.karrotmarket.com/package.json
@@ -8,7 +8,7 @@
     "directory": "us.karrotmarket.com"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop"
   },


### PR DESCRIPTION
See [Adding an Asset Prefix | Gatsby](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/asset-prefix/)

Depends on https://github.com/daangn/terraform-env-prod/pull/142