### PR TITLE
team.daangn.com: 짜잘한 디자인 변경사항들

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-website/src/components/Footer.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-website/src/components/Footer.tsx
@@ -112,11 +112,10 @@ const FooterEntryList = styled("ul", {
 
 const SocialServiceProfileList = styled("ul", {
   display: "flex",
+  flexWrap: "wrap",
+  gap: rem(24),
   padding: 0,
   listStyle: "none",
-  "> * + *": {
-    marginLeft: rem(24),
-  },
 });
 
 const SocialServiceProfileItem = styled("li", {

--- a/team.daangn.com/src/components/DetailLink.tsx
+++ b/team.daangn.com/src/components/DetailLink.tsx
@@ -15,6 +15,8 @@ type DetailLinkProps = {
 
 const Base = styled(Link, {
   display: 'inline-flex',
+  flexWrap: 'wrap',
+  whiteSpace: 'nowrap',
   alignItems: 'center',
   color: '$gray900',
   textDecoration: 'none',

--- a/team.daangn.com/src/components/PrismicTeamContentsDataMainBodyMemberQuoteCarousel.tsx
+++ b/team.daangn.com/src/components/PrismicTeamContentsDataMainBodyMemberQuoteCarousel.tsx
@@ -28,7 +28,7 @@ const Container = styled('section', {
   display: 'grid',
   gap: rem(40),
   
-  '@md': {
+  '@lg': {
     gap: rem(56),
   },
 });
@@ -44,7 +44,9 @@ const Slide = styled('div', {
   '& > *': {
     flexShrink: 0,
     width: '100%',
-    maxWidth: rem(560),
+    '@lg': {
+      maxWidth: rem(560),
+    },
   },
 });
 
@@ -114,7 +116,7 @@ const Dots = styled('div', {
   justifyContent: 'center',
   gap: rem(32),
 
-  '@md': {
+  '@lg': {
     '& > :nth-child(2n)': {
       display: 'none',
     },
@@ -177,7 +179,7 @@ const PrismicTeamContentsDataMainBodyMemberQuoteCarousel: React.FC<PrismicTeamCo
         <Slide
           css={{
             transform: `translateX(calc(-100% * ${slide} - ${rem(40 * slide)}))`,
-            '@md': {
+            '@lg': {
               transform: `translateX(-${rem((560 + 40) * slide)})`,
             },
           }}

--- a/team.daangn.com/src/components/PrismicTeamContentsDataMainBodyMemberQuoteCarousel.tsx
+++ b/team.daangn.com/src/components/PrismicTeamContentsDataMainBodyMemberQuoteCarousel.tsx
@@ -113,6 +113,7 @@ const RightArrowButton = styled(ArrowButton, {
 
 const Dots = styled('div', {
   display: 'flex',
+  flexWrap: 'wrap',
   justifyContent: 'center',
   gap: rem(32),
 

--- a/team.daangn.com/src/components/prismicTeamContentsDataMainBodyMemberQuoteCarousel/ArrowButton.tsx
+++ b/team.daangn.com/src/components/prismicTeamContentsDataMainBodyMemberQuoteCarousel/ArrowButton.tsx
@@ -8,6 +8,7 @@ const ArrowButton = styled('button', {
   border: 'none',
   background: 'none',
   padding: 0,
+  cursor: 'pointer',
   transition: 'opacity 0.2s ease-in-out',
   '&:hover': {
     opacity: 0.64,

--- a/team.daangn.com/src/components/prismicTeamContentsDataMainBodyMemberQuoteCarousel/CarouselItem.tsx
+++ b/team.daangn.com/src/components/prismicTeamContentsDataMainBodyMemberQuoteCarousel/CarouselItem.tsx
@@ -36,6 +36,7 @@ const Container = styled('article', {
 });
 
 const ImageContainer = styled('figure', {
+  display: 'grid',
 });
 
 const QuoteContainer = styled('figure', {

--- a/team.daangn.com/src/pages/jobs/{JobPost.parent__(GreenhouseJob)__ghId}.tsx
+++ b/team.daangn.com/src/pages/jobs/{JobPost.parent__(GreenhouseJob)__ghId}.tsx
@@ -41,12 +41,8 @@ const ButtonContainer = styled('div', {
   flexDirection: 'column',
   gap: rem(20),
 
-  variants: {
-    layout: {
-      column: {
-        flexDirection: 'row',
-      },
-    },
+  '@sm': {
+    flexDirection: 'row',
   },
 });
 
@@ -69,11 +65,18 @@ const JobPostPage: React.FC<JobPostPageProps> = ({
           ),
         }))}
       </ContentWrapper>
-      <ButtonContainer layout={{ '@sm': 'column' }}>
-        <Button to={data.jobPost.applyPath!} type="primary">
+      <ButtonContainer>
+        <Button
+          type="primary"
+          to={data.jobPost.applyPath!}
+          fullWidth={{ '@initial': true, '@sm': false }}
+        >
           지원하기
         </Button>
-        <Button to="/jobs/faq/">
+        <Button
+          to="/jobs/faq/"
+          fullWidth={{ '@initial': true, '@sm': false }}
+        >
           자주 묻는 질문
         </Button>
       </ButtonContainer>


### PR DESCRIPTION
- chore: 캐로셀 버튼에 포인터
- chore: iPad Pro 11 사이즈에서 캐로셀 브레이크 변경
- chore: 지원하기 버튼 모바일 레이아웃 복원
- chore: 푸터 소셜 아이콘 flex wrapping 허용
- chore: DetailLink 래핑 지정
- chore: 멤버 한마디 캐로셀 Dots 래핑 허용
