### PR TITLE
fix: add gatsby-plugin-prismic-previews dependency

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-global-website/package.json
+++ b/_packages/@karrotmarket/gatsby-theme-global-website/package.json
@@ -28,6 +28,7 @@
     "framer-motion": "4.1.17",
     "gatsby-plugin-image": "1.13.0",
     "gatsby-plugin-preload-fonts": "2.13.0",
+    "gatsby-plugin-prismic-previews": "^4.1.3",
     "gatsby-plugin-prismic-schema": "*",
     "gatsby-plugin-react-helmet-async": "1.2.0",
     "gatsby-plugin-sharp": "3.13.0",

--- a/_packages/@karrotmarket/gatsby-theme-global-website/package.json
+++ b/_packages/@karrotmarket/gatsby-theme-global-website/package.json
@@ -29,6 +29,7 @@
     "gatsby-plugin-image": "1.13.0",
     "gatsby-plugin-preload-fonts": "2.13.0",
     "gatsby-plugin-prismic-previews": "^4.1.3",
+    "gatsby-source-prismic": "4.1.2",
     "gatsby-plugin-prismic-schema": "*",
     "gatsby-plugin-react-helmet-async": "1.2.0",
     "gatsby-plugin-sharp": "3.13.0",

--- a/jp.karrotmarket.com/package.json
+++ b/jp.karrotmarket.com/package.json
@@ -21,6 +21,7 @@
     "gatsby": "next",
     "gatsby-plugin-google-gtag": "3.13.0",
     "gatsby-plugin-web-font-loader": "1.0.4",
+    "gatsby-plugin-image": "1.13.0",
     "polished": "4.1.3",
     "react": "next",
     "react-dom": "next",

--- a/team.daangn.com/package.json
+++ b/team.daangn.com/package.json
@@ -51,6 +51,7 @@
     "gatsby-plugin-module-resolver": "1.0.3",
     "gatsby-plugin-next-seo": "1.8.0",
     "gatsby-plugin-prismic-previews": "4.1.3",
+    "gatsby-source-prismic": "4.1.2",
     "gatsby-plugin-prismic-schema": "*",
     "gatsby-plugin-react-helmet-async": "1.2.0",
     "gatsby-plugin-robots-txt": "1.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,7 +7261,7 @@ gatsby-plugin-preload-fonts@2.13.0:
     progress "^2.0.3"
     puppeteer "^3.3.0"
 
-gatsby-plugin-prismic-previews@4.1.3:
+gatsby-plugin-prismic-previews@4.1.3, gatsby-plugin-prismic-previews@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-prismic-previews/-/gatsby-plugin-prismic-previews-4.1.3.tgz#06cf07db735847902ba1bfeb9fd274125f820857"
   integrity sha512-sFfUL9SV6IEaBvX/MOM1DQXbGlQ/BMoanO3BttYYUwS12dVA2dk4ZbkRJ9i5m/Wq0G7I8jxj2ojlOVmA4+vW2A==
@@ -7555,7 +7555,7 @@ gatsby-worker@^0.4.0:
   dependencies:
     "@babel/core" "^7.14.8"
 
-gatsby@3.13.0, gatsby@next:
+gatsby@next:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-3.13.0.tgz#3314b191fa9cb02470a59d54c0dda58e087e1a9a"
   integrity sha512-nZOQkV6CF8ixtkbr+VNeiD2ISwuSkRLafeK+x/1btPB/l+b/w8ar0XrJGIWNX4DHr2Pohf3wy166IPfEkNqNTA==
@@ -12152,7 +12152,7 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@18.0.0-alpha-edfe50510-20210823, react-dom@experimental, react-dom@next:
+react-dom@experimental, react-dom@next:
   version "18.0.0-alpha-edfe50510-20210823"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-edfe50510-20210823.tgz#5a56f55d90c9b4578c97f98559c5dc0b2d35271a"
   integrity sha512-AseRrDncRUdndWQIS26rWNaEd2OB0YcJznzUx8xJjNu/bbExEy4OQmZDVhMWsRJa7+0P+VtQNSFlvt8qtD3CGA==
@@ -12259,7 +12259,7 @@ react-swipeable@6.2.0:
   resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-6.2.0.tgz#057271cb7a6fb4af9d2a3f6d80ccdf33e2f64d47"
   integrity sha512-nWQ8dEM8e/uswZLSIkXUsAnQmnX4MTcryOHBQIQYRMJFDpgDBSiVbKsz/BZVCIScF4NtJh16oyxwaNOepR6xSw==
 
-react@18.0.0-alpha-edfe50510-20210823, react@experimental, react@next:
+react@experimental, react@next:
   version "18.0.0-alpha-edfe50510-20210823"
   resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-alpha-edfe50510-20210823.tgz#11bfeb8f7f30994b9b0bd4f86e1bdda94a61f4d1"
   integrity sha512-8YwjfY+TJQcq81sbZxnImdo79kEjzLlJl1GQhi8O6DYlJVRa0ynYkc7fnRGOYcQNjFvwGDJFYAs95XouJvbN3w==
@@ -12794,7 +12794,12 @@ scheduler@0.21.0-alpha-edfe50510-20210823:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-dts@0.6.0, schema-dts@1.0.0:
+schema-dts@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-0.6.0.tgz#1700eadcc384d39341e0f90ad15d708504124166"
+  integrity sha512-mYfPlwuIssnlBkqcwalddhJp23grXIlpI9sDBQuTzM46pftdzXGhbMMzwoszuWZHsH5Zki+LVDeMKjTPRWiAlw==
+
+schema-dts@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-1.0.0.tgz#60e8a0f2cef5e644c44c843b03d35b37a4423c01"
   integrity sha512-9t8gnY3RW2CbpuvA0pIpcaHFXkJTeNnWR4uaWI+PiYSfpuEeMw+2Q0Gac6YTnQb1B8TR6/+G71gQWuSE7dq6Zw==
@@ -14710,7 +14715,7 @@ webpack-virtual-modules@^0.3.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@5.52.0, webpack@^5.35.0:
+webpack@^5.35.0:
   version "5.52.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.52.0.tgz#88d997c2c3ebb62abcaa453d2a26e0fd917c71a3"
   integrity sha512-yRZOat8jWGwBwHpco3uKQhVU7HYaNunZiJ4AkAVQkPCUGoZk/tiIXiwG+8HIy/F+qsiZvSOa+GLQOj3q5RKRYg==


### PR DESCRIPTION
#237 이후 build 깨지고있어서 `gatsby-plugin-prismic-previews` 가 `gatsby-theme-global-website` dependencies에 누락되어 발생 수정.