### PR TITLE
feat: search index only lowercase

### DIFF
--- a/team.daangn.com/gatsby/gatsby-config.ts
+++ b/team.daangn.com/gatsby/gatsby-config.ts
@@ -163,7 +163,7 @@ const config: GatsbyConfig = {
             for (const word of wordSet) {
               const syllables = disassembleHangul(word);
               for (let i = 0; i < syllables.length; i++) {
-                const token = assembleHangul(syllables.slice(0, i + 1));
+                const token = assembleHangul(syllables.slice(0, i + 1)).toLocaleLowerCase();
                 tokens.push(token);
               }
             }

--- a/team.daangn.com/src/utils/useFlexSearch.tsx
+++ b/team.daangn.com/src/utils/useFlexSearch.tsx
@@ -23,7 +23,7 @@ export const useFlexSearch = (query?: string) => {
   }, [staticData.localSearchJobPosts.publicIndexURL]);
   useEffect(() => {
     if (query) {
-      const results = flexIndex?.[0].flatMap((entities) => entities[query] || []);
+      const results = flexIndex?.[0].flatMap((entities) => entities[query.toLocaleLowerCase()] || []);
       setSearchResult(Array.from(new Set(results)));
     } else {
       setSearchResult(undefined);


### PR DESCRIPTION
#138에서 검색token의 대소문자 구분으로 인해 검색이안되서, case 무시하고 동작하도록 index명은 lowercase로 고정