### PR TITLE
fix: faq text color

### DIFF
--- a/team.daangn.com/src/components/FaqAccordionItem.tsx
+++ b/team.daangn.com/src/components/FaqAccordionItem.tsx
@@ -46,6 +46,7 @@ const Button = styled('button', {
   paddingY: rem(24),
   cursor: 'pointer',
   backgroundColor: 'transparent',
+  color: '$gray900',
   border: 'none',
   flex: 1,
   display: 'flex',


### PR DESCRIPTION
안녕하세요! 서비스 운영개발팀 백엔드 서버 개발 인턴 주디예요.
https://team.daangn.com/faq/ 페이지의 아코디언 텍스트가 iOS15 Safari에서 파란색으로 보이고 있어서 수정했어요.
색상은 피그마를 참고했어요. 감사합니다~ 🙇🏻‍♀️

| 전 | 후 |
|---|---|
| ![IMG_4165](https://user-images.githubusercontent.com/33684401/139535020-8f66c99e-ebd9-4fbc-8956-b3f41f15a78f.PNG) | ![IMG_4166](https://user-images.githubusercontent.com/33684401/139535022-afde20cd-e052-4c37-9516-8e21d0d53cf3.PNG) |
