### PR TITLE
gatsby-theme-team-website: 컨텐츠 모델 업그레이드

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-team-website/gatsby/gatsby-node.ts
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/gatsby/gatsby-node.ts
@@ -1,7 +1,21 @@
-import type { GatsbyNode } from 'gatsby';
+import type { GatsbyNode, Page } from 'gatsby';
 import slugify from 'cjk-slug';
 
 const gql = String.raw;
+
+type PluginOptions = {
+  locale: string,
+  navigationId: string,
+};
+
+export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
+  Joi,
+}) => {
+  return Joi.object({
+    locale: Joi.string().required(),
+    navigationId: Joi.string().required(),
+  });
+};
 
 export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] = ({
   actions,
@@ -73,8 +87,25 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
 export const createPages: GatsbyNode['createPages'] = async ({
   graphql,
   actions,
-}) => {
+}, pluginOptions) => {
+  const {
+    locale,
+    navigationId,
+  } = pluginOptions as unknown as PluginOptions;
+
   type Data = {
+    prismicTeamContents: {
+      data?: {
+        enable_faq_page?: boolean,
+        enable_life_page?: boolean,
+        enable_culture_page?: boolean,
+      },
+    },
+    allPrismicTeamsArticle: {
+      nodes: Array<{
+        uid: string,
+      }>,
+    },
     allJobPost: {
       nodes: Array<{
         id: string,
@@ -90,7 +121,23 @@ export const createPages: GatsbyNode['createPages'] = async ({
   };
 
   const { data, errors } = await graphql<Data>(gql`
-    {
+    query ($locale: String!) {
+      prismicTeamContents(lang: { eq: $locale }) {
+        data {
+          enable_faq_page
+          enable_life_page
+          enable_culture_page
+        }
+      }
+      allPrismicTeamsArticle(
+        filter: {
+          lang: { eq: $locale }
+        }
+      ) {
+        nodes {
+          uid
+        }
+      }
       allJobPost {
         nodes {
           id
@@ -104,7 +151,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
         }
       }
     }
-  `);
+  `, { locale });
 
   if (errors) {
     throw errors;
@@ -114,11 +161,50 @@ export const createPages: GatsbyNode['createPages'] = async ({
     throw new Error('Failed to load data');
   }
 
+  if (!data.prismicTeamContents?.data) {
+    throw new Error(`Prismic ${locale} 에 채용사이트 컨텐츠 데이터가 없습니다.`);
+  }
+
+  if (data.prismicTeamContents.data.enable_faq_page) {
+    actions.createPage({
+      path: '/faq/',
+      component: require.resolve('./src/templates/FaqPage.tsx'),
+      context: {
+        locale,
+        navigationId,
+      },
+    });
+  }
+
+  if (data.prismicTeamContents.data.enable_life_page) {
+    actions.createPage({
+      path: '/culture/life/',
+      component: require.resolve('./src/templates/LifePage.tsx'),
+      context: {
+        locale,
+        navigationId,
+      },
+    });
+  }
+
+  if (data.prismicTeamContents.data.enable_culture_page) {
+    actions.createPage({
+      path: '/culture/',
+      component: require.resolve('./src/templates/CulturePage.tsx'),
+      context: {
+        locale,
+        navigationId,
+      },
+    });
+  }
+
   for (const jobPost of data.allJobPost.nodes) {
     actions.createPage({
       path: `/jobs/${jobPost.ghId}/`,
       component: require.resolve('./src/templates/JobPostPage.tsx'),
       context: {
+        locale,
+        navigationId,
         id: jobPost.id,
         ghId: jobPost.ghId,
       },
@@ -127,6 +213,8 @@ export const createPages: GatsbyNode['createPages'] = async ({
       path: `/jobs/${jobPost.ghId}/apply/`,
       component: require.resolve('./src/templates/JobApplicationPage.tsx'),
       context: {
+        locale,
+        navigationId,
         id: jobPost.id,
         ghId: jobPost.ghId,
       },
@@ -137,6 +225,8 @@ export const createPages: GatsbyNode['createPages'] = async ({
     path: `/jobs/`,
     component: require.resolve('./src/templates/JobsPage.tsx'),
     context: {
+      locale,
+      navigationId,
       pattern: `/.*/`,
       chapter: null,
       slug: null,
@@ -150,10 +240,46 @@ export const createPages: GatsbyNode['createPages'] = async ({
       path: `/jobs/${slug}/`,
       component: require.resolve('./src/templates/JobsPage.tsx'),
       context: {
+        locale,
+        navigationId,
         pattern: `/${slug}/`,
         chapter,
         slug,
       },
     });
   }
+
+  for (const article of data.allPrismicTeamsArticle.nodes) {
+    actions.createPage({
+      path: `/jobs/article/${article.uid}/`,
+      component: require.resolve('./src/templates/PrismicTeamsArticlePage.tsx'),
+      context: {
+        locale,
+        navigationId,
+        uid: article.uid,
+      },
+    });
+  }
 };
+
+export const onCreatePage: GatsbyNode['onCreateNode'] = ({
+  page: _page,
+  actions,
+}, pluginOptions) => {
+  const {
+    locale,
+    navigationId,
+  } = pluginOptions as unknown as PluginOptions;
+
+  const page = _page as Page;
+
+  actions.deletePage(page);
+  actions.createPage({
+    ...page,
+    context: {
+      ...page.context,
+      locale,
+      navigationId,
+    },
+  });
+}

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/Button.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/Button.tsx
@@ -9,6 +9,7 @@ const Button = styled(Link, {
   justifyContent: 'center',
   fontSize: '$subtitle4',
   fontWeight: 'bold',
+  textAlign: 'center',
   height: rem(60),
   border: 'none',
   borderRadius: rem(10),

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/FaqAccordion.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/FaqAccordion.tsx
@@ -7,12 +7,12 @@ import FaqAccordionItem from './FaqAccordionItem';
 
 type FaqAccordionProps = {
   className?: string,
-  faqData: GatsbyTypes.TeamWebsite_FaqAccordion_faqDataFragment,
+  data: GatsbyTypes.TeamWebsite_FaqAccordion_faqDataFragment,
 };
 
 export const query = graphql`
-  fragment TeamWebsite_FaqAccordion_faqData on PrismicFaqDataType {
-    entries {
+  fragment TeamWebsite_FaqAccordion_faqData on PrismicTeamContentsDataType {
+    faq_entries {
       ...TeamWebsite_FaqAccordionItem_entry
     }
   }
@@ -52,14 +52,14 @@ const reducer: React.Reducer<State, Action> = (state, action) => {
 
 const FaqAccordion: React.FC<FaqAccordionProps> = ({
   className,
-  faqData,
+  data,
 }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
   return (
     <Container className={className}>
       <AnimatePresence initial={false}>
-        {faqData.entries
+        {data.faq_entries
         .filter(entry => entry.question && entry.answer)
         .map(entry => (
           <FaqAccordionItem

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/FaqAccordionItem.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/FaqAccordionItem.tsx
@@ -16,7 +16,7 @@ type FaqAccordionItemProps = {
 };
 
 export const query = graphql`
-  fragment TeamWebsite_FaqAccordionItem_entry on PrismicFaqDataEntries {
+  fragment TeamWebsite_FaqAccordionItem_entry on PrismicTeamContentsDataFaqEntries {
     question
     answer {
       html

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/DefaultLayout.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/DefaultLayout.tsx
@@ -23,14 +23,19 @@ type DefaultLayoutProps = OverrideProps<
 
 export const query = graphql`
   fragment TeamWebsite_DefaultLayout_query on Query {
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       _previewable
       data {
         fb_app_id
         twitter_site_handle
       }
     }
-    prismicSiteNavigation(uid: { eq: "team.daangn.com" }) {
+    prismicSiteNavigation(
+      lang: { eq: $locale }
+      uid: { eq: $navigationId }
+    ) {
       _previewable
       data {
         ...Header_navigationData

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/JobPostLayout.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/JobPostLayout.tsx
@@ -24,7 +24,10 @@ type JobPostLayoutProps = OverrideProps<
 
 export const query = graphql`
   fragment TeamWebsite_JobPostLayout_query on Query {
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
+      _previewable
       data {
         jobs_page_meta_title
         jobs_page_meta_description

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/pages/index.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/pages/index.tsx
@@ -20,9 +20,14 @@ import PrismicTeamContentsDataMainBodyWideBanner from '../components/PrismicTeam
 type IndexPageProps = PageProps<GatsbyTypes.TeamWebsite_IndexPageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_IndexPage {
+  query TeamWebsite_IndexPage(
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       _previewable
       data {
         main_page_meta_title

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/pages/preview.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/pages/preview.tsx
@@ -16,7 +16,10 @@ type PreviewResolverPageProps = (
 );
 
 export const query = graphql`
-  query TeamWebsite_PreviewResolverPage {
+  query TeamWebsite_PreviewResolverPage(
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
   }
 `;

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/CulturePage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/CulturePage.tsx
@@ -20,9 +20,14 @@ import PrismicTeamContentsDataCultureBodyIllustrationAndDescription from '../com
 type CulturePageProps = PageProps<GatsbyTypes.TeamWebsite_CulturePageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_CulturePage {
+  query TeamWebsite_CulturePage(
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       _previewable
       data {
         culture_page_meta_title

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/FaqPage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/FaqPage.tsx
@@ -12,23 +12,26 @@ import FaqAccordion from '../components/FaqAccordion';
 type FaqPageProps = PageProps<GatsbyTypes.TeamWebsite_FaqPageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_FaqPage {
+  query TeamWebsite_FaqPage(
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
-
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       _previewable
       data {
-        jobs_page_meta_title
-        jobs_page_meta_description
         twitter_site_handle
-      }
-    }
 
-    prismicFaq(uid: { eq: "team.daangn.com" }) {
-      _previewable
-      data {
+        faq_page_meta_title
+        faq_page_meta_description
+        faq_page_title {
+          text
+        }
+
         ...TeamWebsite_FaqAccordion_faqData
-        entries {
+        faq_entries {
           question
           answer {
             text
@@ -56,27 +59,27 @@ const FaqPage: React.FC<FaqPageProps> = ({
   data,
 }) => {
   required(data.prismicTeamContents?.data);
-  required(data.prismicFaq?.data);
 
   return (
     <Container>
       <GatsbySeo
-        title={`자주 묻는 질문 | ${data.prismicTeamContents.data.jobs_page_meta_title}`}
+        title={data.prismicTeamContents.data.faq_page_meta_title}
+        description={data.prismicTeamContents.data.faq_page_meta_description}
         twitter={data.prismicTeamContents.data.twitter_site_handle != null ? {
           cardType: 'summary',
           site: data.prismicTeamContents.data.twitter_site_handle,
         } : undefined}
       />
       <FAQJsonLd
-        questions={data.prismicFaq.data.entries!.map(faq => ({
+        questions={data.prismicTeamContents.data.faq_entries!.map(faq => ({
           question: faq!.question || '',
           answer: faq!.answer!.text || '',
         }))}
       />
       <PageTitle>
-        자주 묻는 질문
+        {data.prismicTeamContents.data.faq_page_title.text}
       </PageTitle>
-      <FaqAccordion faqData={data.prismicFaq.data} />
+      <FaqAccordion data={data.prismicTeamContents.data} />
     </Container>
   );
 };

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobApplicationPage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobApplicationPage.tsx
@@ -21,7 +21,11 @@ import messages from './jobApplicationPage/messages';
 type JobApplicationPageProps = PageProps<GatsbyTypes.TeamWebsite_JobApplicationPageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_JobApplicationPage($id: String!) {
+  query TeamWebsite_JobApplicationPage(
+    $id: String!
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
     ...TeamWebsite_JobPostLayout_query
     jobPost(id: { eq: $id }) {
@@ -30,7 +34,10 @@ export const query = graphql`
       boardToken
       portfolioRequired
     }
-    privacyPolicy: prismicTermsAndConditions(uid: { eq: "job-application-privacy" }) {
+    privacyPolicy: prismicTermsAndConditions(
+      uid: { eq: "job-application-privacy" }
+      lang: { eq: $locale }
+    ) {
       id
       data {
         content {
@@ -38,7 +45,10 @@ export const query = graphql`
         }
       }
     }
-    sensitiveInfoPolicy: prismicTermsAndConditions(uid: { eq: "job-application-sensitive" }) {
+    sensitiveInfoPolicy: prismicTermsAndConditions(
+      uid: { eq: "job-application-sensitive" }
+      lang: { eq: $locale }
+    ) {
       id
       data {
         content {

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobPostPage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobPostPage.tsx
@@ -15,7 +15,11 @@ import messages from './jobPostPage/messages';
 type JobPostPageProps = PageProps<GatsbyTypes.TeamWebsite_JobPostPageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_JobPostPage($id: String!) {
+  query TeamWebsite_JobPostPage(
+    $id: String!
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
     ...TeamWebsite_JobPostLayout_query
     jobPost(id: { eq: $id }) {

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobsPage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/JobsPage.tsx
@@ -18,10 +18,16 @@ import messages from './jobsPage/messages';
 type JobsPageTemplateProps = PageProps<GatsbyTypes.TeamWebsite_JobsPageTemplateQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_JobsPageTemplate($pattern: String) {
+  query TeamWebsite_JobsPageTemplate(
+    $pattern: String
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
 
-    prismicTeamContents {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       data {
         jobs_page_meta_title
         jobs_page_meta_description

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/LifePage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/LifePage.tsx
@@ -2,29 +2,31 @@ import * as React from 'react';
 import { rem } from 'polished';
 import type { PageProps } from 'gatsby';
 import { graphql } from 'gatsby';
-import { GatsbySeo } from 'gatsby-plugin-next-seo';
 import { styled } from 'gatsby-theme-stitches/src/config';
-import { required, Condition } from '@cometjs/core';
+import { GatsbySeo } from 'gatsby-plugin-next-seo';
+import { required } from '@cometjs/core';
 import { mapAbstractTypeWithDefault } from '@cometjs/graphql-utils';
 import { useSiteOrigin } from '@karrotmarket/gatsby-theme-website/src/siteMetadata';
 
-import { withPrismicPreview } from 'gatsby-plugin-prismic-previews';
-import { defaultRepositoryConfig } from '@karrotmarket/gatsby-theme-prismic/src/defaultRepositoryConfig';
+import _PageTitle from '../components/PageTitle';
+import PrismicTeamContentsDataLifeBodyLifeContent from '../components/PrismicTeamContentsDataLifeBodyLifeContent';
 
-import _PageTitle from '../../../components/PageTitle';
-import PrismicTeamsArticleDataBodyArticleSection from '../../../components/PrismicTeamsArticleDataBodyArticleSection';
-
-type TeamsArticlePageProps = PageProps<GatsbyTypes.TeamWebsite_TeamsArticlePageQuery, GatsbyTypes.SitePageContext>;
+type LifePageProps = PageProps<GatsbyTypes.TeamWebsite_LifePageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_TeamsArticlePage($uid: String!) {
+  query TeamWebsite_LifePage(
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
-    prismicTeamsArticle(uid: { eq: $uid }) {
+    prismicTeamContents(
+      lang: { eq: $locale }
+    ) {
       _previewable
       data {
-        page_meta_title
-        page_meta_description
-        page_meta_image {
+        life_page_meta_title
+        life_page_meta_description
+        life_page_meta_image {
           localFile {
             childImageSharp {
               fixed(
@@ -40,12 +42,12 @@ export const query = graphql`
             }
           }
         }
-        page_title {
+        life_page_title {
           text
         }
-        body {
+        life_body {
           __typename
-          ...PrismicTeamsArticleDataBodyArticleSection_data
+          ...PrismicTeamContentsDataLifeBodyLifeContent_data
         }
       }
     }
@@ -72,18 +74,16 @@ const Content = styled('div', {
   gap: rem(64),
 });
 
-
-
-const TeamsArticlePage: React.FC<TeamsArticlePageProps> = ({
+const LifePage: React.FC<LifePageProps> = ({
   data,
 }) => {
   const siteOrigin = useSiteOrigin();
 
-  required(data.prismicTeamsArticle?.data?.body);
+  required(data.prismicTeamContents?.data?.life_body);
 
-  const metaTitle = data.prismicTeamsArticle.data.page_meta_title;
-  const metaDescription = data.prismicTeamsArticle.data.page_meta_description;
-  const metaImage = data.prismicTeamsArticle.data.page_meta_image?.localFile?.childImageSharp?.fixed;
+  const metaTitle = data.prismicTeamContents.data.life_page_meta_title;
+  const metaDescription = data.prismicTeamContents.data.life_page_meta_description;
+  const metaImage = data.prismicTeamContents.data.life_page_meta_image?.localFile?.childImageSharp?.fixed;
 
   return (
     <Container>
@@ -108,18 +108,16 @@ const TeamsArticlePage: React.FC<TeamsArticlePageProps> = ({
         }}
       />
       <PageTitle>
-        {data.prismicTeamsArticle.data.page_title?.text}
+        {data.prismicTeamContents.data.life_page_title?.text}
       </PageTitle>
       <Content>
-        {data.prismicTeamsArticle.data.body
-          .filter(Condition.isTruthy)
-          .map((data, i) => mapAbstractTypeWithDefault(data, {
-            PrismicTeamsArticleDataBodyArticleSection: data => (
-              <PrismicTeamsArticleDataBodyArticleSection
-                key={i}
-                data={data}
-              />
-            ),
+        {data.prismicTeamContents.data.life_body.map((data, i) => mapAbstractTypeWithDefault(data!, {
+          PrismicTeamContentsDataLifeBodyLifeContent: data => (
+            <PrismicTeamContentsDataLifeBodyLifeContent
+              key={i}
+              data={data}
+            />
+          ),
           _: null,
         }))}
       </Content>
@@ -127,6 +125,4 @@ const TeamsArticlePage: React.FC<TeamsArticlePageProps> = ({
   );
 };
 
-export default withPrismicPreview(TeamsArticlePage, [
-  defaultRepositoryConfig,
-]);
+export default LifePage;

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/PrismicTeamsArticlePage.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/templates/PrismicTeamsArticlePage.tsx
@@ -2,26 +2,33 @@ import * as React from 'react';
 import { rem } from 'polished';
 import type { PageProps } from 'gatsby';
 import { graphql } from 'gatsby';
-import { styled } from 'gatsby-theme-stitches/src/config';
 import { GatsbySeo } from 'gatsby-plugin-next-seo';
-import { required } from '@cometjs/core';
+import { styled } from 'gatsby-theme-stitches/src/config';
+import { required, Condition } from '@cometjs/core';
 import { mapAbstractTypeWithDefault } from '@cometjs/graphql-utils';
 import { useSiteOrigin } from '@karrotmarket/gatsby-theme-website/src/siteMetadata';
 
-import _PageTitle from '../../components/PageTitle';
-import PrismicTeamContentsDataLifeBodyLifeContent from '../../components/PrismicTeamContentsDataLifeBodyLifeContent';
+import { withPrismicPreview } from 'gatsby-plugin-prismic-previews';
+import { defaultRepositoryConfig } from '@karrotmarket/gatsby-theme-prismic/src/defaultRepositoryConfig';
 
-type LifePageProps = PageProps<GatsbyTypes.TeamWebsite_LifePageQuery, GatsbyTypes.SitePageContext>;
+import _PageTitle from '../components/PageTitle';
+import PrismicTeamsArticleDataBodyArticleSection from '../components/PrismicTeamsArticleDataBodyArticleSection';
+
+type TeamsArticlePageProps = PageProps<GatsbyTypes.TeamWebsite_TeamsArticlePageQuery, GatsbyTypes.SitePageContext>;
 
 export const query = graphql`
-  query TeamWebsite_LifePage {
+  query TeamWebsite_TeamsArticlePage(
+    $uid: String!
+    $locale: String!
+    $navigationId: String!
+  ) {
     ...TeamWebsite_DefaultLayout_query
-    prismicTeamContents {
+    prismicTeamsArticle(uid: { eq: $uid }) {
       _previewable
       data {
-        life_page_meta_title
-        life_page_meta_description
-        life_page_meta_image {
+        page_meta_title
+        page_meta_description
+        page_meta_image {
           localFile {
             childImageSharp {
               fixed(
@@ -37,12 +44,12 @@ export const query = graphql`
             }
           }
         }
-        life_page_title {
+        page_title {
           text
         }
-        life_body {
+        body {
           __typename
-          ...PrismicTeamContentsDataLifeBodyLifeContent_data
+          ...PrismicTeamsArticleDataBodyArticleSection_data
         }
       }
     }
@@ -69,16 +76,18 @@ const Content = styled('div', {
   gap: rem(64),
 });
 
-const LifePage: React.FC<LifePageProps> = ({
+
+
+const TeamsArticlePage: React.FC<TeamsArticlePageProps> = ({
   data,
 }) => {
   const siteOrigin = useSiteOrigin();
 
-  required(data.prismicTeamContents?.data?.life_body);
+  required(data.prismicTeamsArticle?.data?.body);
 
-  const metaTitle = data.prismicTeamContents.data.life_page_meta_title;
-  const metaDescription = data.prismicTeamContents.data.life_page_meta_description;
-  const metaImage = data.prismicTeamContents.data.life_page_meta_image?.localFile?.childImageSharp?.fixed;
+  const metaTitle = data.prismicTeamsArticle.data.page_meta_title;
+  const metaDescription = data.prismicTeamsArticle.data.page_meta_description;
+  const metaImage = data.prismicTeamsArticle.data.page_meta_image?.localFile?.childImageSharp?.fixed;
 
   return (
     <Container>
@@ -103,16 +112,18 @@ const LifePage: React.FC<LifePageProps> = ({
         }}
       />
       <PageTitle>
-        {data.prismicTeamContents.data.life_page_title?.text}
+        {data.prismicTeamsArticle.data.page_title?.text}
       </PageTitle>
       <Content>
-        {data.prismicTeamContents.data.life_body.map((data, i) => mapAbstractTypeWithDefault(data!, {
-          PrismicTeamContentsDataLifeBodyLifeContent: data => (
-            <PrismicTeamContentsDataLifeBodyLifeContent
-              key={i}
-              data={data}
-            />
-          ),
+        {data.prismicTeamsArticle.data.body
+          .filter(Condition.isTruthy)
+          .map((data, i) => mapAbstractTypeWithDefault(data, {
+            PrismicTeamsArticleDataBodyArticleSection: data => (
+              <PrismicTeamsArticleDataBodyArticleSection
+                key={i}
+                data={data}
+              />
+            ),
           _: null,
         }))}
       </Content>
@@ -120,4 +131,6 @@ const LifePage: React.FC<LifePageProps> = ({
   );
 };
 
-export default LifePage;
+export default withPrismicPreview(TeamsArticlePage, [
+  defaultRepositoryConfig,
+]);

--- a/_packages/@karrotmarket/prismic-config/schema/team_contents.json
+++ b/_packages/@karrotmarket/prismic-config/schema/team_contents.json
@@ -39,7 +39,7 @@
         "labels" : {
           "key_visual" : [ ],
           "member_quote_carousel" : [ ],
-          "title_and_description" : [ {
+         "title_and_description" : [ {
             "name" : "title_and_description",
             "display" : "Title and Description"
           } ],
@@ -810,22 +810,6 @@
       }
     }
   },
-  "Meta" : {
-    "fb_app_id" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Facebook App ID",
-        "placeholder" : "Facebook for Developers 에서 앱 만들 것"
-      }
-    },
-    "twitter_site_handle" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Twitter Username",
-        "placeholder" : "(기본: daangnteam)"
-      }
-    }
-  },
   "Apply Completed" : {
     "completed_page_message" : {
       "type" : "StructuredText",
@@ -839,6 +823,35 @@
       "config" : {
         "single" : "strong,em,hyperlink",
         "label" : "Contact"
+      }
+    },
+    "completed_page_content" : {
+      "type" : "StructuredText",
+      "config" : {
+        "multi" : "paragraph,strong,em,hyperlink",
+        "label" : "내용",
+        "placeholder" : "지원 완료 후 보이는 안내 문구를 적어주세요."
+      }
+    },
+    "completed_page_link_group" : {
+      "type" : "Group",
+      "config" : {
+        "fields" : {
+          "display_text" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "바로가기"
+            }
+          },
+          "link" : {
+            "type" : "Link",
+            "config" : {
+              "label" : "바로가기 링크",
+              "select" : null
+            }
+          }
+        },
+        "label" : "completed_page_link_group"
       }
     },
     "completed_body" : {
@@ -880,6 +893,123 @@
             "repeat" : { }
           }
         }
+      }
+    }
+  },
+  "FAQ" : {
+    "faq_page_meta_title" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "페이지 제목 (메타)"
+      }
+    },
+    "faq_page_meta_description" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "페이지 설명 (메타)"
+      }
+    },
+    "faq_page_title" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "heading1",
+        "label" : "페이지 제목"
+      }
+    },
+    "faq_entries" : {
+      "type" : "Group",
+      "config" : {
+        "fields" : {
+          "question" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "질문",
+              "placeholder" : "질문 내용을 입력하세요"
+            }
+          },
+          "answer" : {
+            "type" : "StructuredText",
+            "config" : {
+              "multi" : "paragraph,strong,em,hyperlink,list-item,o-list-item",
+              "label" : "답변",
+              "placeholder" : "답변 내용을 입력하세요"
+            }
+          }
+        },
+        "label" : "FAQ 항목"
+      }
+    }
+  },
+  "Not Found" : {
+    "notfound_page_title" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "heading1",
+        "label" : "페이지 제목"
+      }
+    },
+    "notfound_page_link_group" : {
+      "type" : "Group",
+      "config" : {
+        "fields" : {
+          "display_text" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "바로가기"
+            }
+          },
+          "link" : {
+            "type" : "Link",
+            "config" : {
+              "label" : "바로가기 링크",
+              "select" : null
+            }
+          }
+        },
+        "label" : "notfound_page_link_group"
+      }
+    }
+  },
+  "Meta" : {
+    "enable_culture_page" : {
+      "type" : "Boolean",
+      "config" : {
+        "placeholder_false" : "사용안함",
+        "placeholder_true" : "사용",
+        "default_value" : false,
+        "label" : "Culture 페이지 사용"
+      }
+    },
+    "enable_life_page" : {
+      "type" : "Boolean",
+      "config" : {
+        "placeholder_false" : "사용안함",
+        "placeholder_true" : "사용",
+        "default_value" : false,
+        "label" : "Life 페이지 사용"
+      }
+    },
+    "enable_faq_page" : {
+      "type" : "Boolean",
+      "config" : {
+        "placeholder_false" : "사용안함",
+        "placeholder_true" : "사용",
+        "default_value" : false,
+        "label" : "FAQ 페이지 사용"
+      }
+    },
+    "fb_app_id" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Facebook App ID",
+        "placeholder" : "Facebook for Developers 에서 앱 만들 것"
+      }
+    },
+    "twitter_site_handle" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Twitter Username",
+        "placeholder" : "(기본: daangnteam)"
       }
     }
   }

--- a/team.daangn.com/gatsby/gatsby-config.ts
+++ b/team.daangn.com/gatsby/gatsby-config.ts
@@ -104,7 +104,13 @@ const config: GatsbyConfig = {
     },
 
     // 커스텀 플러그인
-    '@karrotmarket/gatsby-theme-team-website',
+    {
+      resolve: '@karrotmarket/gatsby-theme-team-website',
+      options: {
+        locale: 'ko-kr',
+        navigationId: 'team.daangn.com',
+      },
+    },
     {
       resolve: '@karrotmarket/gatsby-source-greenhouse-jobboard',
       options: {


### PR DESCRIPTION
- 지역화된 컨텐츠 설정
- 페이지 대부분 다 커스터마이징 가능하도록 스키마
- FAQ 컨텐츠 모델 병합 (관리와 지역화 용이)
- 페이지 토글
- 불필요한 슬라이스 모델 제거