### PR TITLE
[WMAS-15] JobPost.chapter -> JobDepartment 마이그레이션

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-team-website/package.json
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/package.json
@@ -29,7 +29,6 @@
     "@stitches/react": "1.2.6",
     "@svgr/webpack": "6.2.1",
     "babel-plugin-polished": "1.1.0",
-    "cjk-slug": "0.3.0",
     "clsx": "1.1.1",
     "focus-trap-react": "8.9.1",
     "framer-motion": "4.1.17",

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/JobPostList.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/JobPostList.tsx
@@ -9,26 +9,25 @@ import FadeInWhenVisible from './FadeInWhenVisible';
 import EmptyPlaceholder from './jobPostList/EmptyPlaceholder';
 
 type JobPostListProps = {
-  jobs: GatsbyTypes.TeamWebsite_JobPostList_jobPostsFragment,
+  jobPosts: GatsbyTypes.TeamWebsite_JobPostList_jobPostsFragment,
   className?: string,
-  filterChapter?: string,
   filterEmploymentType?: string,
   searchResults?: string[],
 };
 
 export const query = graphql`
-  fragment TeamWebsite_JobPostList_jobs on JobPostConnection {
-    nodes {
+  fragment TeamWebsite_JobPostList_jobPosts on JobPost {
+    id
+    ghId
+    # Avoid File System Route API
+    # pagePath: gatsbyPath(filePath: "/jobs/{JobPost.ghId}")
+    externalUrl
+    order
+    departments {
       id
-      ghId
-      # Avoid File System Route API
-      # pagePath: gatsbyPath(filePath: "/jobs/{JobPost.ghId}")
-      externalUrl
-      chapter
-      order
-      employmentType
-      ...TeamWebsite_JobPostSummary_jobPost
     }
+    employmentType
+    ...TeamWebsite_JobPostSummary_jobPost
   }
 `;
 
@@ -57,15 +56,12 @@ const JobPostListItem = styled('li', {
 });
 
 const JobPostList: React.FC<JobPostListProps> = ({
-  jobs,
+  jobPosts,
   className,
-  filterChapter = '',
   filterEmploymentType = '',
   searchResults
 }) => {
   const parseLink = useLinkParser();
-
-  const jobPosts = jobs.nodes;
 
   const orderedJobPosts = jobPosts 
     .sort((a, b) => b.order - a.order);
@@ -74,10 +70,6 @@ const JobPostList: React.FC<JobPostListProps> = ({
     .filter(jobPosts =>{
       if(!searchResults) return true;
       return searchResults.includes(jobPosts.id)
-    })
-    .filter(jobPost => {
-      if (filterChapter === '') return true;
-      return jobPost.chapter === filterChapter;
     })
     .filter(jobPost => {
       if (filterEmploymentType === '') return true;

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/JobPostLayout.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/layouts/JobPostLayout.tsx
@@ -61,7 +61,6 @@ export const query = graphql`
       id
       ghId
       title
-      chapter
       corporate
       employmentType
       priorExperience

--- a/_packages/@karrotmarket/gatsby-transformer-job-post/gatsby/gatsby-node.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-job-post/gatsby/gatsby-node.ts
@@ -1,10 +1,11 @@
+import slugify from 'cjk-slug';
+import type { GatsbyNode, NodeInput } from 'gatsby';
 import type {
-  GatsbyNode,
-  Node,
-  NodeInput
-} from 'gatsby';
-import { isGreenhouseJobNode } from './types';
+  GreenhouseJobBoardDepartmentNode,
+  GreenhouseJobBoardJobNode,
+} from '@karrotmarket/gatsby-source-greenhouse-jobboard/types';
 
+import { isGreenhouseDepartmentNode, isGreenhouseJobNode } from './types';
 import * as greenhouseJobBlockParser from './greenhouseJobBlockParser';
 import * as greenhouseJobCustomFieldParser from './greenhouseJobCustomFieldParser';
 export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
@@ -21,12 +22,225 @@ type PluginOptions = {
   },
 };
 
-export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] = ({
-  actions,
-  schema,
-  reporter,
-}) => {
+export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] = (ctx, options) => {
+  const { actions, schema } = ctx;
+  const { defaultTags = {} } = options as unknown as PluginOptions;
+
   const gql = String.raw;
+  const fieldParser = greenhouseJobCustomFieldParser;
+
+  actions.createTypes([
+    schema.buildObjectType({
+      name: 'JobPost',
+      interfaces: ['Node'],
+      extensions: {
+        dontInfer: {},
+        childOf: {
+          types: ['GreenhouseJobBoardJob'],
+        },
+      },
+      fields: {
+        ghId: {
+          type: 'String!',
+        },
+        parentJob: {
+          type: 'GreenhouseJobBoardJob!',
+          extensions: {
+            link: {
+              from: 'parent',
+            },
+          },
+        },
+        updatedAt: {
+          type: 'Date!',
+          extensions: {
+            dateformat: {},
+          },
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return source.updated_at;
+          },
+        },
+        validThrough: {
+          type: 'Date',
+          description: '공고 유효기간',
+          extensions: {
+            dateformat: {},
+          },
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.validThrough(source, ctx) ?? null;
+          },
+        },
+        title: {
+          type: 'String!',
+        },
+        boardToken: {
+          type: 'String!',
+        },
+        boardUrl: {
+          type: 'String!',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return source.absolute_url;
+          },
+        },
+        content: {
+          type: '[JobPostContentSection!]!',
+          description: 'Parsed content',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            const { content } = greenhouseJobBlockParser.parseContent(source.content);
+            return content;
+          },
+        },
+        rawContent: {
+          type: 'String!',
+          description: 'HTML content (unsafe)',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return source.content;
+          },
+        },
+        corporate: {
+          type: 'JobCorporate', // 이거 왜 nullable 이더라...?
+          description: '회사 (당근마켓, 당근페이)',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.corporate(source, ctx);
+          },
+        },
+        employmentType: {
+          type: 'JobEmploymentType!',
+          description: '고용 형태',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.employmentType(source, ctx) ?? 'FULL_TIME';
+          },
+        },
+        alternativeCivilianService: {
+          type: 'Boolean!',
+          description: '산업기능요원 근무 가능합니까?',
+          resolve(sourcsource: GreenhouseJobBoardJobNode) {
+            return fieldParser.alternativeCivilianService(sourcsource, ctx) ?? false;
+          },
+        },
+        priorExperience: {
+          type: 'JobPriorExperience!',
+          description: '경력? 신입?',
+          resolve(sourcsourcsource: GreenhouseJobBoardJobNode) {
+            return fieldParser.priorExperience(sourcsourcsource, ctx) ?? 'YES';
+          },
+        },
+        chapter: {
+          type: 'String!',
+          description: '소속 챕터 (=직무)',
+          deprecationReason: 'departments로 대체됨',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.chapter(source, ctx) ?? '';
+          },
+        },
+        departments: {
+          type: '[JobDepartment!]!',
+          description: '소속',
+          async resolve(source: GreenhouseJobBoardJobNode, _args, ctx) {
+            const departmentIds = source.departments
+              .filter(department => !department.child_ids.length)
+              .filter(department => department.id !== 0)
+              .map(department => department.id.toString());
+
+            const { entries } = await ctx.nodeModel.findAll({
+              type: 'JobDepartment',
+              query: {
+                filter: {
+                  ghId: {
+                    in: departmentIds,
+                  },
+                },
+                sort: {
+                  fields: ['name'],
+                  order: ['ASC'],
+                },
+              },
+            });
+
+            return entries;
+          },
+        },
+        keywords: {
+          type: '[String!]!',
+          description: '검색 키워드',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.keywords(source, ctx) ?? [];
+          },
+        },
+        order: {
+          type: 'Int!',
+          description: '정렬 선호 순위 값 (signed, 기본값: 0)',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.order(source, ctx) ?? 0;
+          },
+        },
+        externalUrl: {
+          type: 'String',
+          description: '외부 링크 (공고가 바깥에서 열리는 경우.. 좀 컨텐츠 많으면 노션 링크 선호되는 경우 있음)',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return fieldParser.externalUrl(source, ctx)?.toString() ?? null;
+          },
+        },
+        tags: {
+          type: '[String!]!',
+          description: '목록에서 표시할 태그',
+          resolve(source: GreenhouseJobBoardJobNode) {
+            return [...defaultTags[source.boardToken] ?? [], ...fieldParser.tags(source, ctx) ?? [] ];
+          },
+        },
+      },
+    }),
+
+    schema.buildObjectType({
+      name: 'JobDepartment',
+      interfaces: ['Node'],
+      extensions: {
+        dontInfer: {},
+        childOf: {
+          types: ['GreenhouseJobBoardJob'],
+        },
+      },
+      fields: {
+        ghId: {
+          type: 'String!',
+          resolve(source: GreenhouseJobBoardDepartmentNode) {
+            return source.ghId.toString();
+          },
+        },
+        name: {
+          type: 'String!',
+        },
+        slug: {
+          type: 'String',
+          resolve(source: GreenhouseJobBoardDepartmentNode) {
+            return slugify(source.name);
+          },
+        },
+        jobPosts: {
+          type: '[JobPost!]!',
+          async resolve(source: GreenhouseJobBoardDepartmentNode, _args, ctx) {
+            const { entries } = await ctx.nodeModel.findAll({
+              type: 'JobPost',
+              query: {
+                filter: {
+                  departments: {
+                    elemMatch: {
+                      ghId: { eq: source.ghId.toString() },
+                    },
+                  },
+                },
+                sort: {
+                  fields: ['order', 'title'],
+                  order: ['DESC', 'ASC'],
+                },
+              },
+            });
+            return entries;
+          },
+        },
+      },
+    }),
+  ]);
 
   actions.createTypes(gql`
     # 이건 assertion이 안되네
@@ -34,61 +248,6 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       childJobPost: JobPost!
     }
 
-    type JobPost implements Node
-      @dontInfer
-      @childOf(types: ["GreenhouseJobBoardJob"])
-    {
-      ghId: String!
-
-      parentJob: GreenhouseJobBoardJob! @link(from: "parent")
-
-      updatedAt: Date! @dateformat
-
-      # 공고 유효 기간
-      validThrough: Date @dateformat
-
-      title: String!
-
-      boardToken: String!
-
-      boardUrl: String!
-
-      # Parsed content
-      content: [JobPostContentSection!]!
-
-      # HTML content (unsafe)
-      rawContent: String!
-
-      # 회사 (당근마켓, 당근페이)
-      corporate: JobCorporate
-
-      # 고용 형태
-      employmentType: JobEmploymentType!
-
-      # 산업기능요원 근무 가능합니까?
-      alternativeCivilianService: Boolean!
-
-      # 경력? 신입?
-      priorExperience: JobPriorExperience!
-
-      # 소속 챕터 (=직무)
-      chapter: String!
-
-      # 검색 키워드
-      keywords: [String!]!
-
-      # 정렬 선호 순위 값 (signed, 기본값: 0)
-      order: Int!
-
-      # 외부 링크 (공고가 바깥에서 열리는 경우.. 좀 컨텐츠 많으면 노션 링크 선호되는 경우 있음)
-      externalUrl: String
-
-      # 목록에서 표시할 태그
-      tags: [String!]!
-    }
-  `);
-
-  actions.createTypes(gql`
     enum JobCorporate {
       KARROT_MARKET
       KARROT_PAY
@@ -136,49 +295,45 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = (ctx,options) => {
     createNodeId,
     createContentDigest,
   } = ctx;
-  const { defaultTags = {} } = options as unknown as PluginOptions;
-
-  // Note: 나중에 다른 타입 추가로 transform 할 수 있으므로 early return 하지 않겠습니다.
   if (isGreenhouseJobNode(node)) {
-    const { content, raw: rawContent } = greenhouseJobBlockParser.parseContent(node.content);
-    const fieldParser = greenhouseJobCustomFieldParser;
-
-    const nodeSource = {
-      id: createNodeId(`GreenhouseJobBoardJob:${node.id} >>> JobPost`),
-      updatedAt: node.updated_at,
-      ghId: node.ghId.toString(),
-      title: node.title,
-      boardToken: node.boardToken,
-      boardUrl: node.absolute_url,
-      rawContent,
-      content,
-      validThrough: fieldParser.validThrough(node, ctx) ?? null,
-      corporate: fieldParser.corporate(node, ctx),
-      employmentType: fieldParser.employmentType(node, ctx) ?? 'FULL_TIME',
-      alternativeCivilianService: fieldParser.alternativeCivilianService(node, ctx) ?? false,
-      priorExperience: fieldParser.priorExperience(node, ctx) ?? 'YES',
-      chapter: fieldParser.chapter(node, ctx) ?? '',
-      keywords: fieldParser.keywords(node, ctx) ?? [],
-      order: fieldParser.order(node, ctx) ?? 0,
-      externalUrl: fieldParser.externalUrl(node, ctx)?.toString() ?? null,
-      tags: [ ...defaultTags[node.boardToken] ?? [], ...fieldParser.tags(node, ctx) ?? [] ],
-    };
-
     const jobPostNode: NodeInput = {
+      ...node,
+      id: createNodeId(`GreenhouseJobBoardJob:${node.id} >>> JobPost`),
       parent: node.id,
       children: [],
       internal: {
         type: 'JobPost',
-        contentDigest: createContentDigest(nodeSource),
+        contentDigest: createContentDigest(node),
       },
-      ...nodeSource,
     };
 
     actions.createNode(jobPostNode);
     actions.createParentChildLink({
       parent: node,
-      // See https://github.com/gatsbyjs/gatsby/issues/19993
-      child: jobPostNode as unknown as Node,
+      child: jobPostNode,
+    });
+
+  } else if (isGreenhouseDepartmentNode(node)) {
+    // Leaf node 만 다룸
+    if (node.child_ids.length) {
+      return;
+    }
+
+    const jobChapterNode: NodeInput = {
+      ...node,
+      id: createNodeId(`GreenhouseJobBoardDepartment:${node.id} >>> JobChapter`),
+      parent: node.id,
+      children: [],
+      internal: {
+        type: 'JobDepartment',
+        contentDigest: createContentDigest(node),
+      },
+    };
+
+    actions.createNode(jobChapterNode);
+    actions.createParentChildLink({
+      parent: node,
+      child: jobChapterNode,
     });
   }
 };

--- a/_packages/@karrotmarket/gatsby-transformer-job-post/gatsby/types.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-job-post/gatsby/types.ts
@@ -1,6 +1,13 @@
 import type { Node } from 'gatsby';
-import type { GreenhouseJobBoardJobNode } from '@karrotmarket/gatsby-source-greenhouse-jobboard/types';
+import type {
+  GreenhouseJobBoardDepartmentNode,
+  GreenhouseJobBoardJobNode,
+} from '@karrotmarket/gatsby-source-greenhouse-jobboard/types';
 
 export function isGreenhouseJobNode(node: Node): node is GreenhouseJobBoardJobNode {
   return node.internal.type === 'GreenhouseJobBoardJob';
+}
+
+export function isGreenhouseDepartmentNode(node: Node): node is GreenhouseJobBoardDepartmentNode {
+  return node.internal.type === 'GreenhouseJobBoardDepartment';
 }

--- a/_packages/@karrotmarket/gatsby-transformer-job-post/package.json
+++ b/_packages/@karrotmarket/gatsby-transformer-job-post/package.json
@@ -25,6 +25,7 @@
     "@types/node": "16.11.22",
     "babel-jest": "27.5.0",
     "babel-preset-gatsby-package": "2.6.0",
+    "cjk-slug": "0.3.0",
     "common-tags": "1.8.2",
     "concurrently": "7.0.0",
     "gatsby": "next",

--- a/team.daangn.com/src/@karrotmarket/gatsby-theme-team-website/layouts/jobPostLayout/generateProperties.ts
+++ b/team.daangn.com/src/@karrotmarket/gatsby-theme-team-website/layouts/jobPostLayout/generateProperties.ts
@@ -1,6 +1,5 @@
 type JobPostLike = {
   corporate?: string,
-  chapter?: string,
   employmentType?: string,
   priorExperience?: string,
 }
@@ -16,10 +15,6 @@ export default function *generateProperties(jobPost: JobPostLike): Generator<str
     }
   }
   
-  if (jobPost.chapter) {
-    yield jobPost.chapter;
-  }
-
   if (jobPost.employmentType) {
     const employmentType = {
       FULL_TIME: '정규직',


### PR DESCRIPTION
변경된 점
- `JobPost.chapter` is deprecated
- `JobDepartment` 타입 추가
- gatsby-transformer-job-post 플러그인에 커스텀 리졸버 적용
  - transform 로직이 이제 필요할 때만 수행됩니다.
  - `JobPost` <-> `JobDepartment` 백링킹 지원
- JobPostList 페이지 쿼리 `JobDepartment` 기준으로 변경
- department 는 Greenhouse에서 글로벌로 관리되므로 이제 퍼머링크가 Job Opening 상태와 상관없이 보존됩니다.
- `JobPostLayout` 에서 `chapter` 필드 노출하던 부분 제거했습니다.
- `chapter` 와 다르게 `departments` 는 job post 한 개 당 여러개가 연관될 수 있으므로 이 후 다룰 때 주의가 필요합니다.
- 공고 필터 스타일을 더 다양한 뷰포트에 적응하도록 개선했습니다.
- 안쓰는 코드 제거