### PR TITLE
team-website: fix culture nav button text color

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/PrismicTeamContentsDataCultureBodyHowWeWork.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/PrismicTeamContentsDataCultureBodyHowWeWork.tsx
@@ -93,6 +93,7 @@ const EntryGroupNavButton = styled('button', {
   border: 'none',
   cursor: 'pointer',
   typography: '$subtitle3',
+  color: vars.$scale.color.gray900,
   variants: {
     active: {
       true: {


### PR DESCRIPTION
안녕하세요~ 운영개발팀 주디에요 😀 
모바일로 [당근마켓 팀 문화 페이지](https://team.daangn.com/culture/)를 보다가 중간에 버튼이 파란색으로 나와서 슬쩍 수정해봤어요...!
참고로 저는 iOS 15.2.1 / Safari에서 50%로 축소해서 봤어요. 감사합니다 🙇‍♀️ 

앗... 빌드가 깨지네요... 😰 제가 gatsby cloud 권한이 없어서 로그 확인이 어려운 상황인데, 혹시 고쳐야 할 부분이 있으면 알려주세요 🙏 

| 라이트 모드 (전) | 라이트 모드 (후) |
|--|--|
| ![IMG_5970](https://user-images.githubusercontent.com/33684401/169875609-0ef6218c-6f5f-442c-b667-c3ca96b2fa59.jpg) | ![IMG_5971](https://user-images.githubusercontent.com/33684401/169875646-978e91ae-8e66-4d79-bb8e-d100017e0632.jpg) |

| 다크 모드 (전) | 다크 모드 (후) |
|--|--|
| ![IMG_5972](https://user-images.githubusercontent.com/33684401/169875653-c54ecfc7-8e2b-46b6-a976-5b74c7b2db1e.jpg) | ![IMG_5973](https://user-images.githubusercontent.com/33684401/169875660-7e9c1a01-5900-4fbc-8c12-b8baacab1784.jpg) |