### PR TITLE
fix: add break-all to description field

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/formField/Field.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/formField/Field.tsx
@@ -57,4 +57,7 @@ export const Description = styled('p', {
   color: vars.$scale.color.gray600,
   marginTop: rem(16),
   wordBreak: 'break-all',
+  '@md': {
+    wordBreak: 'keep-all',
+  },
 });

--- a/_packages/@karrotmarket/gatsby-theme-team-website/src/components/formField/Field.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-team-website/src/components/formField/Field.tsx
@@ -56,4 +56,5 @@ export const Input = styled('input', {
 export const Description = styled('p', {
   color: vars.$scale.color.gray600,
   marginTop: rem(16),
+  wordBreak: 'break-all',
 });


### PR DESCRIPTION
<img width="421" alt="스크린샷 2022-08-17 오후 3 11 53" src="https://user-images.githubusercontent.com/20167165/185047242-86ca8fa9-bd53-4abb-a8e6-5d6a68f8e21c.png">

- Field Description에 break-all 속성을 적용해요