### PR TITLE
fix: button text color

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-website-team/src/components/Button.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-website-team/src/components/Button.tsx
@@ -26,7 +26,7 @@ const Button = styled(Link, {
         },
       },
       primary: {
-        color: vars.$static.color.white,
+        color: vars.$static.color.staticWhite,
         backgroundColor: vars.$scale.color.carrot500,
         '&:hover': {
           backgroundColor: vars.$scale.color.carrot600,


### PR DESCRIPTION
안녕하세요. 
채용 페이지 버튼 색이 누락되는 문제가 있어서 조금 수정해 봤는데 확인 부탁드립니다.

<img width="345" alt="color" src="https://user-images.githubusercontent.com/67104761/204335283-851fab31-7721-4631-a84f-0b1ced730ca3.png">

|라이트 모드 (전)|라이트 모드 (후)|
|---|---|
|<img width="586" alt="w-button-1" src="https://user-images.githubusercontent.com/67104761/204334780-1aaa2011-47d6-4764-97c6-66a47846578e.png">| <img width="606" alt="w-button-2" src="https://user-images.githubusercontent.com/67104761/204334829-7700fb8c-099c-4cae-9fd6-1508c6ab14f8.png">|

|다크 모드 (전)|다크 모드 (후)|
|---|---|
|<img width="584" alt="b-button-1" src="https://user-images.githubusercontent.com/67104761/204334938-5447e33f-2e37-42b6-9307-41b96c553d69.png">|<img width="589" alt="b-button-2" src="https://user-images.githubusercontent.com/67104761/204334980-89ca50c1-dbef-4c65-94f9-d88e1a963c39.png">|