### PR TITLE
feat: add slices for post

### DIFF
--- a/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-node.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-node.ts
@@ -4,6 +4,10 @@ import { createRemoteFileNode } from 'gatsby-source-filesystem';
 
 import {
   type PrismicMemberProfileNode,
+  type PrismicPostDataBodyCtaButtonSlice,
+  type PrismicPostDataBodyGroupImageSectionSlice,
+  type PrismicPostDataBodyQuoteSectionSlice,
+  type PrismicPostDataBodyVerticalQuoteSectionSlice,
   type PrismicPostNode,
   type PrismicPostRichTextSectionSlice,
   isPrismicMemberProfile,
@@ -153,11 +157,35 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
           },
         },
         body: {
-          type: '[PostRichTextSection!]!',
+          type: '[PostBodyItem!]!',
           resolve(node: PrismicPostNode) {
             return node.data.body;
           },
         },
+      },
+    }),
+    schema.buildUnionType({
+      name: 'PostBodyItem',
+      types: [
+        'PostRichTextSection',
+        'PostGroupImageSection',
+        'PostQuoteSection',
+        'PostVerticalQuoteSection',
+        'PostCtaButtonSection',
+      ],
+      resolveType(parent: PrismicPostNode['data']['body'][number]) {
+        switch (parent.slice_type) {
+          case 'rich_text_section':
+            return 'PostRichTextSection';
+          case 'group_image_section':
+            return 'PostGroupImageSection';
+          case 'quote_section':
+            return 'PostQuoteSection';
+          case 'vertical_quote_section':
+            return 'PostVerticalQuoteSection';
+          case 'cta_button':
+            return 'PostCtaButtonSection';
+        }
       },
     }),
     schema.buildObjectType({
@@ -193,6 +221,142 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         primary: {
           type: 'JSON!',
           resolve(parent: PrismicPostRichTextSectionSlice) {
+            return parent.primary;
+          },
+        },
+      },
+    }),
+    schema.buildObjectType({
+      name: 'PostGroupImageSection',
+      extensions: {
+        dontInfer: {},
+      },
+      fields: {
+        id: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            return parent.id;
+          },
+        },
+        sliceType: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            return parent.slice_type;
+          },
+        },
+        groupImage1: {
+          type: 'File!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            if (!parent.primary.group_image1.url) {
+              throw new Error(
+                `GroupImageSection 의 image 필드 값이 비어있습니다. prismicId: ${parent.id}`,
+              );
+            }
+            return createRemoteFileNode({
+              url: parent.primary.group_image1.url,
+              createNode,
+              createNodeId,
+              cache,
+            });
+          },
+        },
+        groupImage2: {
+          type: 'File!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            if (!parent.primary.group_image2.url) {
+              throw new Error(
+                `GroupImageSection 의 image 필드 값이 비어있습니다. prismicId: ${parent.id}`,
+              );
+            }
+            return createRemoteFileNode({
+              url: parent.primary.group_image2.url,
+              createNode,
+              createNodeId,
+              cache,
+            });
+          },
+        },
+        groupImageCaption: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            return parent.primary.group_image_caption;
+          },
+        },
+      },
+    }),
+    schema.buildObjectType({
+      name: 'PostQuoteSection',
+      extensions: {
+        dontInfer: {},
+      },
+      fields: {
+        id: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyQuoteSectionSlice) {
+            return parent.id;
+          },
+        },
+        sliceType: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyQuoteSectionSlice) {
+            return parent.slice_type;
+          },
+        },
+        primary: {
+          type: 'JSON!',
+          resolve(parent: PrismicPostDataBodyQuoteSectionSlice) {
+            return parent.primary;
+          },
+        },
+      },
+    }),
+    schema.buildObjectType({
+      name: 'PostVerticalQuoteSection',
+      extensions: {
+        dontInfer: {},
+      },
+      fields: {
+        id: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyVerticalQuoteSectionSlice) {
+            return parent.id;
+          },
+        },
+        sliceType: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyVerticalQuoteSectionSlice) {
+            return parent.slice_type;
+          },
+        },
+        primary: {
+          type: 'JSON!',
+          resolve(parent: PrismicPostDataBodyVerticalQuoteSectionSlice) {
+            return parent.primary;
+          },
+        },
+      },
+    }),
+    schema.buildObjectType({
+      name: 'PostCtaButtonSection',
+      extensions: {
+        dontInfer: {},
+      },
+      fields: {
+        id: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyCtaButtonSlice) {
+            return parent.id;
+          },
+        },
+        sliceType: {
+          type: 'String!',
+          resolve(parent: PrismicPostDataBodyCtaButtonSlice) {
+            return parent.slice_type;
+          },
+        },
+        primary: {
+          type: 'JSON!',
+          resolve(parent: PrismicPostDataBodyCtaButtonSlice) {
             return parent.primary;
           },
         },

--- a/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-node.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-node.ts
@@ -282,6 +282,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
             return parent.primary.group_image_caption;
           },
         },
+        primary: {
+          type: 'JSON!',
+          resolve(parent: PrismicPostDataBodyGroupImageSectionSlice) {
+            return parent.primary;
+          },
+        },
       },
     }),
     schema.buildObjectType({

--- a/_packages/@karrotmarket/gatsby-transformer-post/gatsby/types.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-post/gatsby/types.ts
@@ -42,7 +42,13 @@ export type PrismicPostNode = PrismicSourceNode &
       related_posts: GroupField<{
         post: ContentRelationshipField<'post'>;
       }>;
-      body: SliceZone<PrismicPostRichTextSectionSlice>;
+      body: SliceZone<
+        | PrismicPostRichTextSectionSlice
+        | PrismicPostDataBodyGroupImageSectionSlice
+        | PrismicPostDataBodyQuoteSectionSlice
+        | PrismicPostDataBodyVerticalQuoteSectionSlice
+        | PrismicPostDataBodyCtaButtonSlice
+      >;
     },
     'post'
   >;
@@ -55,6 +61,50 @@ export type PrismicPostRichTextSectionSlice = Slice<
     slice_type: string;
     primary: RichTextField;
     items: RichTextField;
+  }
+>;
+
+export type PrismicPostDataBodyGroupImageSectionSlice = Slice<
+  'group_image_section',
+  {
+    id: string;
+    slice_type: string;
+    group_image_caption: string;
+    group_image1: ImageField;
+    group_image2: ImageField;
+  }
+>;
+
+export type PrismicPostDataBodyQuoteSectionSlice = Slice<
+  'quote_section',
+  {
+    id: string;
+    slice_type: string;
+    primary: RichTextField;
+  }
+>;
+
+export type PrismicPostDataBodyVerticalQuoteSectionSlice = Slice<
+  'vertical_quote_section',
+  {
+    id: string;
+    slice_type: string;
+    primary: RichTextField;
+  }
+>;
+
+export type PrismicPostDataBodyCtaButtonSlice = Slice<
+  'cta_button',
+  {
+    id: string;
+    slice_type: string;
+    primary: {
+      cta_button_text: string;
+      cta_phrase: string;
+      cta_button_url: {
+        url: string;
+      };
+    };
   }
 >;
 

--- a/about.daangn.com/package.json
+++ b/about.daangn.com/package.json
@@ -56,6 +56,7 @@
     "@babel/core": "7.21.3",
     "@types/dotenv-safe": "8.1.2",
     "@types/node": "18.15.11",
+    "@types/prismjs": "1.26.0",
     "@types/react": "18.0.31",
     "@types/react-dom": "18.0.11",
     "babel-preset-gatsby-package": "3.8.0",

--- a/about.daangn.com/src/assets/icon_quote_close.svg
+++ b/about.daangn.com/src/assets/icon_quote_close.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 17H17L19 13V7H13V13H16M6 17H9L11 13V7H5V13H8L6 17Z" fill="currentColor"/>
+</svg>

--- a/about.daangn.com/src/assets/icon_quote_open.svg
+++ b/about.daangn.com/src/assets/icon_quote_open.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 7L8 11H11V17H5V11L7 7H10ZM18 7L16 11H19V17H13V11L15 7H18Z" fill="currentColor"/>
+</svg>

--- a/about.daangn.com/src/components/blogPostPage/PostBodyCtaButton.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyCtaButton.tsx
@@ -1,28 +1,36 @@
-import { PrismicRichText } from '@prismicio/react';
 import { vars } from '@seed-design/design-token';
 import { styled } from 'gatsby-theme-stitches/src/config';
 import { rem } from 'polished';
 import React from 'react';
 
-const PostBodyCtaButton = ({
-  slice,
-}: {
+type PostBodyCtaButtonProps = {
   slice: GatsbyTypes.PostCtaButtonSection;
-}) => {
+};
+
+const PostBodyCtaButton: React.FC<PostBodyCtaButtonProps> = ({ slice }) => {
   return (
     <Container>
       <p>{slice.primary.cta_phrase}</p>
       <Button
-        onClick={() => {window.location.href = slice.primary.cta_button_url?.url}}
-      >{slice.primary.cta_button_text}</Button>
+        onClick={() => {
+          window.location.href = slice.primary.cta_button_url?.url;
+        }}
+      >
+        {slice.primary.cta_button_text}
+      </Button>
     </Container>
   );
 };
 
 const Container = styled('section', {
   width: '100%',
-  margin: `${rem(100)} 0`,
+  marginTop: rem(100),
+  marginBottom: rem(60),
   textAlign: 'center',
+  color: vars.$scale.color.gray700,
+  borderRadius: rem(22),
+  // backgroundColor: vars.$scale.color.gray100,
+  // padding: `${rem(40)} 0`,
 });
 
 const Button = styled('button', {

--- a/about.daangn.com/src/components/blogPostPage/PostBodyCtaButton.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyCtaButton.tsx
@@ -1,0 +1,41 @@
+import { PrismicRichText } from '@prismicio/react';
+import { vars } from '@seed-design/design-token';
+import { styled } from 'gatsby-theme-stitches/src/config';
+import { rem } from 'polished';
+import React from 'react';
+
+const PostBodyCtaButton = ({
+  slice,
+}: {
+  slice: GatsbyTypes.PostCtaButtonSection;
+}) => {
+  return (
+    <Container>
+      <p>{slice.primary.cta_phrase}</p>
+      <Button
+        onClick={() => {window.location.href = slice.primary.cta_button_url?.url}}
+      >{slice.primary.cta_button_text}</Button>
+    </Container>
+  );
+};
+
+const Container = styled('section', {
+  width: '100%',
+  margin: `${rem(100)} 0`,
+  textAlign: 'center',
+});
+
+const Button = styled('button', {
+  width: rem(100),
+  height: rem(40),
+  marginTop: rem(20),
+  border: `2px solid ${vars.$scale.color.carrot500}`,
+  borderRadius: rem(4),
+  backgroundColor: vars.$scale.color.carrot500,
+  fontWeight: 'bold',
+  fontSize: '$body3',
+  color: vars.$scale.color.gray100,
+  cursor: 'pointer',
+});
+
+export default PostBodyCtaButton;

--- a/about.daangn.com/src/components/blogPostPage/PostBodyGroupImage.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyGroupImage.tsx
@@ -1,23 +1,67 @@
-import { PrismicRichText } from '@prismicio/react';
 import { vars } from '@seed-design/design-token';
+import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { styled } from 'gatsby-theme-stitches/src/config';
 import { rem } from 'polished';
 import React from 'react';
 
-const PostBodyGroupImage = ({
-  slice,
-}: {
+type PostBodyGroupImageProps = {
   slice: GatsbyTypes.PostGroupImageSection;
-}) => {
+};
+
+const PostBodyGroupImage: React.FC<PostBodyGroupImageProps> = ({ slice }) => {
+  const groupImage1 =
+    slice.groupImage1.childImageSharp?.gatsbyImageData &&
+    getImage(slice.groupImage1.childImageSharp?.gatsbyImageData);
+  const groupImage2 =
+    slice.groupImage2.childImageSharp?.gatsbyImageData &&
+    getImage(slice.groupImage2.childImageSharp?.gatsbyImageData);
+  const groupImage1Alt = slice.primary.group_image1.alt || '';
+  const groupImage2Alt = slice.primary.group_image2.alt || '';
+  const groupImageCaption = slice.groupImageCaption;
+
+  if (!(groupImage1 && groupImage2)) {
+    return null;
+  }
+
   return (
     <Container>
-      <h2>그룹 이미지 섹션</h2>
+      <GroupImageWrapper>
+        <ImageWrapper>
+          <Image image={groupImage1} alt={groupImage1Alt} />
+        </ImageWrapper>
+        <ImageWrapper>
+          <Image image={groupImage2} alt={groupImage2Alt} />
+        </ImageWrapper>
+      </GroupImageWrapper>
+      {groupImageCaption && <Caption>{groupImageCaption}</Caption>}
     </Container>
   );
 };
 
 const Container = styled('section', {
   width: '100%',
+});
+
+const GroupImageWrapper = styled('div', {
+  display: 'flex',
+  flexDirection: 'row',
+  gap: rem(12),
+});
+
+const ImageWrapper = styled('div', {
+  width: '50%',
+});
+
+const Image = styled(GatsbyImage, {
+  width: '100%',
+});
+
+const Caption = styled('p', {
+  textAlign: 'center',
+  color: vars.$scale.color.gray600,
+  typography: '$caption2',
+  marginTop: rem(8),
+  marginBottom: rem(32),
 });
 
 export default PostBodyGroupImage;

--- a/about.daangn.com/src/components/blogPostPage/PostBodyGroupImage.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyGroupImage.tsx
@@ -1,0 +1,23 @@
+import { PrismicRichText } from '@prismicio/react';
+import { vars } from '@seed-design/design-token';
+import { styled } from 'gatsby-theme-stitches/src/config';
+import { rem } from 'polished';
+import React from 'react';
+
+const PostBodyGroupImage = ({
+  slice,
+}: {
+  slice: GatsbyTypes.PostGroupImageSection;
+}) => {
+  return (
+    <Container>
+      <h2>그룹 이미지 섹션</h2>
+    </Container>
+  );
+};
+
+const Container = styled('section', {
+  width: '100%',
+});
+
+export default PostBodyGroupImage;

--- a/about.daangn.com/src/components/blogPostPage/PostBodyQuote.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyQuote.tsx
@@ -4,14 +4,14 @@ import { styled } from 'gatsby-theme-stitches/src/config';
 import { rem } from 'polished';
 import React from 'react';
 
-import { ReactComponent as QuoteOpen } from '../../assets/icon_quote_open.svg';
 import { ReactComponent as QuoteClose } from '../../assets/icon_quote_close.svg';
+import { ReactComponent as QuoteOpen } from '../../assets/icon_quote_open.svg';
 
-const PostBodyQuote = ({
-  slice,
-}: {
+type PostBodyQuoteProps = {
   slice: GatsbyTypes.PostQuoteSection;
-}) => {
+};
+
+const PostBodyQuote: React.FC<PostBodyQuoteProps> = ({ slice }) => {
   return (
     <Container>
       <QuoteOpen />
@@ -19,9 +19,9 @@ const PostBodyQuote = ({
         field={slice.primary.quote}
         components={{
           paragraph: ({ children, key }) => <QuoteText key={key}>{children}</QuoteText>,
-          heading3: ({ children, key }) => (<Heading3 key={key}>{children}</Heading3>),
-          heading4: ({ children, key }) => (<Heading4 key={key}>{children}</Heading4>),
-          heading5: ({ children, key }) => (<Heading5 key={key}>{children}</Heading5>),
+          heading3: ({ children, key }) => <Heading3 key={key}>{children}</Heading3>,
+          heading4: ({ children, key }) => <Heading4 key={key}>{children}</Heading4>,
+          heading5: ({ children, key }) => <Heading5 key={key}>{children}</Heading5>,
         }}
       />
       <QuoteClose />

--- a/about.daangn.com/src/components/blogPostPage/PostBodyQuote.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyQuote.tsx
@@ -1,0 +1,57 @@
+import { PrismicRichText } from '@prismicio/react';
+import { vars } from '@seed-design/design-token';
+import { styled } from 'gatsby-theme-stitches/src/config';
+import { rem } from 'polished';
+import React from 'react';
+
+import { ReactComponent as QuoteOpen } from '../../assets/icon_quote_open.svg';
+import { ReactComponent as QuoteClose } from '../../assets/icon_quote_close.svg';
+
+const PostBodyQuote = ({
+  slice,
+}: {
+  slice: GatsbyTypes.PostQuoteSection;
+}) => {
+  return (
+    <Container>
+      <QuoteOpen />
+      <PrismicRichText
+        field={slice.primary.quote}
+        components={{
+          paragraph: ({ children, key }) => <QuoteText key={key}>{children}</QuoteText>,
+          heading3: ({ children, key }) => (<Heading3 key={key}>{children}</Heading3>),
+          heading4: ({ children, key }) => (<Heading4 key={key}>{children}</Heading4>),
+          heading5: ({ children, key }) => (<Heading5 key={key}>{children}</Heading5>),
+        }}
+      />
+      <QuoteClose />
+    </Container>
+  );
+};
+
+const Container = styled('section', {
+  width: '100%',
+  textAlign: 'center',
+  color: vars.$scale.color.gray600,
+});
+
+const QuoteText = styled('p', {
+  margin: `${rem(20)} 0`,
+});
+
+const Heading3 = styled(QuoteText, {
+  typography: '$subtitle1',
+  fontWeight: 'bold',
+});
+
+const Heading4 = styled(QuoteText, {
+  typography: '$subtitle2',
+  fontWeight: 'bold',
+});
+
+const Heading5 = styled(QuoteText, {
+  typography: '$subtitle3',
+  fontWeight: 'bold',
+});
+
+export default PostBodyQuote;

--- a/about.daangn.com/src/components/blogPostPage/PostBodyRichText.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyRichText.tsx
@@ -6,11 +6,11 @@ import Prism from 'prismjs';
 import 'prismjs/themes/prism-tomorrow.css';
 import React from 'react';
 
-const PostBodyRichText = ({
-  slice,
-}: {
+type PostBodyRichTextProps = {
   slice: GatsbyTypes.PostRichTextSection;
-}) => {
+};
+
+const PostBodyRichText: React.FC<PostBodyRichTextProps> = ({ slice }) => {
   React.useEffect(() => {
     Prism.highlightAll();
   }, []);
@@ -59,10 +59,11 @@ const PostBodyRichText = ({
 
 const Container = styled('section', {
   width: '100%',
-  lineHeight: rem(24),
+  marginBottom: rem(10),
   fontSize: '$body2',
-  color: vars.$scale.color.gray700,
+  lineHeight: rem(24),
   letterSpacing: rem(0.1),
+  color: vars.$scale.color.gray700,
 
   '& a': {
     color: vars.$scale.color.gray700,

--- a/about.daangn.com/src/components/blogPostPage/PostBodyRichText.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyRichText.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 const PostBodyRichText = ({
   slice,
 }: {
-  slice: Queries.PostRichTextSection;
+  slice: GatsbyTypes.PostRichTextSection;
 }) => {
   React.useEffect(() => {
     Prism.highlightAll();

--- a/about.daangn.com/src/components/blogPostPage/PostBodyVerticalQuote.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyVerticalQuote.tsx
@@ -4,16 +4,14 @@ import { styled } from 'gatsby-theme-stitches/src/config';
 import { rem } from 'polished';
 import React from 'react';
 
-const PostBodyVerticalQuote = ({
-  slice,
-}: {
+type PostBodyVerticalQuoteProps = {
   slice: GatsbyTypes.PostVerticalQuoteSection;
-}) => {
+};
+
+const PostBodyVerticalQuote: React.FC<PostBodyVerticalQuoteProps> = ({ slice }) => {
   return (
     <Container>
-      <PrismicRichText
-        field={slice.primary.vertical_quote}
-      />
+      <PrismicRichText field={slice.primary.vertical_quote} />
     </Container>
   );
 };
@@ -21,8 +19,18 @@ const PostBodyVerticalQuote = ({
 const Container = styled('section', {
   boxSizing: 'border-box',
   width: '100%',
+  margin: `${rem(12)} 0`,
   paddingLeft: rem(16),
   borderLeft: `4px solid ${vars.$scale.color.gray700}`,
+  fontSize: '$body2',
+  lineHeight: rem(24),
+  letterSpacing: rem(0.1),
+
+  '@sm': {
+    fontSize: '$body1',
+    lineHeight: rem(28),
+    letterSpacing: rem(0.4),
+  },
 });
 
 export default PostBodyVerticalQuote;

--- a/about.daangn.com/src/components/blogPostPage/PostBodyVerticalQuote.tsx
+++ b/about.daangn.com/src/components/blogPostPage/PostBodyVerticalQuote.tsx
@@ -1,0 +1,28 @@
+import { PrismicRichText } from '@prismicio/react';
+import { vars } from '@seed-design/design-token';
+import { styled } from 'gatsby-theme-stitches/src/config';
+import { rem } from 'polished';
+import React from 'react';
+
+const PostBodyVerticalQuote = ({
+  slice,
+}: {
+  slice: GatsbyTypes.PostVerticalQuoteSection;
+}) => {
+  return (
+    <Container>
+      <PrismicRichText
+        field={slice.primary.vertical_quote}
+      />
+    </Container>
+  );
+};
+
+const Container = styled('section', {
+  boxSizing: 'border-box',
+  width: '100%',
+  paddingLeft: rem(16),
+  borderLeft: `4px solid ${vars.$scale.color.gray700}`,
+});
+
+export default PostBodyVerticalQuote;

--- a/about.daangn.com/src/pages/service.tsx
+++ b/about.daangn.com/src/pages/service.tsx
@@ -2,6 +2,7 @@ import { vars } from '@seed-design/design-token';
 import { type HeadProps, Link, type PageProps, graphql } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import { styled } from 'gatsby-theme-stitches/src/config';
+import { HeadSeo, OpenGraph, TwitterCard } from 'gatsby-plugin-head-seo/src';
 import { rem } from 'polished';
 import * as React from 'react';
 
@@ -163,6 +164,49 @@ const ServicePage: React.FC<ServicePageProps> = ({ data }) => {
         },
       )}
     </Container>
+  );
+};
+
+type ServicePageHeadProps = HeadProps<GatsbyTypes.ServicePageQuery>;
+
+export const Head: React.FC<ServicePageHeadProps> = ({ data, location }) => {
+  const { service_page_meta_title, service_page_meta_description, service_page_og_image } = data.prismicServiceContent?.data;
+  const metaImage = service_page_og_image?.localFile?.childImageSharp?.fixed;
+
+  return (
+    <HeadSeo
+      location={location}
+      root
+      title={service_page_meta_title}
+      description={service_page_meta_description}
+    >
+      {(props) => [
+        <OpenGraph
+          og={{
+            ...props,
+            type: 'website',
+            ...(metaImage && {
+              images: [
+                {
+                  url: new URL(
+                    metaImage.src,
+                    metaImage.src.startsWith('http') ? metaImage.src : props.url,
+                  ),
+                  width: metaImage.width,
+                  height: metaImage.height,
+                },
+              ],
+            }),
+          }}
+        />,
+        <TwitterCard
+          card={{
+            ...props,
+            type: 'summary',
+          }}
+        />,
+      ]}
+    </HeadSeo>
   );
 };
 

--- a/about.daangn.com/src/pages/service.tsx
+++ b/about.daangn.com/src/pages/service.tsx
@@ -170,7 +170,8 @@ const ServicePage: React.FC<ServicePageProps> = ({ data }) => {
 type ServicePageHeadProps = HeadProps<GatsbyTypes.ServicePageQuery>;
 
 export const Head: React.FC<ServicePageHeadProps> = ({ data, location }) => {
-  const { service_page_meta_title, service_page_meta_description, service_page_og_image } = data.prismicServiceContent?.data;
+  const { service_page_meta_title, service_page_meta_description, service_page_og_image } =
+    data.prismicServiceContent?.data;
   const metaImage = service_page_og_image?.localFile?.childImageSharp?.fixed;
 
   return (

--- a/about.daangn.com/src/templates/BlogMainPage.tsx
+++ b/about.daangn.com/src/templates/BlogMainPage.tsx
@@ -1,5 +1,6 @@
-import { type PageProps, graphql } from 'gatsby';
+import { type HeadProps, type PageProps, graphql } from 'gatsby';
 import { styled } from 'gatsby-theme-stitches/src/config';
+import { HeadSeo, OpenGraph, TwitterCard } from 'gatsby-plugin-head-seo/src';
 import { rem } from 'polished';
 import React from 'react';
 
@@ -19,10 +20,13 @@ export const query = graphql`
           text
         }
         blog_page_og_image {
-          alt
           localFile {
             childImageSharp {
-              gatsbyImageData
+              fixed(width: 1200, height: 630, toFormat: PNG, quality: 90) {
+                src
+                width
+                height
+              }
             }
           }
         }
@@ -45,6 +49,49 @@ const BlogMainPage: React.FC<BlogMainPageProps> = ({ data, pageContext }) => {
       <Navigation query={data} pageContext={pageContext.id} />
       <PostList data={data} />
     </Container>
+  );
+};
+
+type BlogPageHeadProps = HeadProps<GatsbyTypes.BlogPageQuery>;
+
+export const Head: React.FC<BlogPageHeadProps> = ({ data, location }) => {
+  const { blog_page_meta_title, blog_page_meta_description, blog_page_og_image } = data.prismicBlogContent?.data;
+  const metaImage = blog_page_og_image?.localFile?.childImageSharp?.fixed;
+
+  return (
+    <HeadSeo
+      location={location}
+      root
+      title={blog_page_meta_title}
+      description={blog_page_meta_description}
+    >
+      {(props) => [
+        <OpenGraph
+          og={{
+            ...props,
+            type: 'website',
+            ...(metaImage && {
+              images: [
+                {
+                  url: new URL(
+                    metaImage.src,
+                    metaImage.src.startsWith('http') ? metaImage.src : props.url,
+                  ),
+                  width: metaImage.width,
+                  height: metaImage.height,
+                },
+              ],
+            }),
+          }}
+        />,
+        <TwitterCard
+          card={{
+            ...props,
+            type: 'summary',
+          }}
+        />,
+      ]}
+    </HeadSeo>
   );
 };
 

--- a/about.daangn.com/src/templates/BlogMainPage.tsx
+++ b/about.daangn.com/src/templates/BlogMainPage.tsx
@@ -55,7 +55,8 @@ const BlogMainPage: React.FC<BlogMainPageProps> = ({ data, pageContext }) => {
 type BlogPageHeadProps = HeadProps<GatsbyTypes.BlogPageQuery>;
 
 export const Head: React.FC<BlogPageHeadProps> = ({ data, location }) => {
-  const { blog_page_meta_title, blog_page_meta_description, blog_page_og_image } = data.prismicBlogContent?.data;
+  const { blog_page_meta_title, blog_page_meta_description, blog_page_og_image } =
+    data.prismicBlogContent?.data;
   const metaImage = blog_page_og_image?.localFile?.childImageSharp?.fixed;
 
   return (

--- a/about.daangn.com/src/templates/BlogPostPage.tsx
+++ b/about.daangn.com/src/templates/BlogPostPage.tsx
@@ -6,11 +6,11 @@ import { rem } from 'polished';
 import * as React from 'react';
 
 import Author from '../components/blogPostPage/Author';
-import PostBodyRichText from '../components/blogPostPage/PostBodyRichText';
+import PostBodyCtaButton from '../components/blogPostPage/PostBodyCtaButton';
 import PostBodyGroupImage from '../components/blogPostPage/PostBodyGroupImage';
 import PostBodyQuote from '../components/blogPostPage/PostBodyQuote';
+import PostBodyRichText from '../components/blogPostPage/PostBodyRichText';
 import PostBodyVerticalQuote from '../components/blogPostPage/PostBodyVerticalQuote';
-import PostBodyCtaButton from '../components/blogPostPage/PostBodyCtaButton';
 import PostFooter from '../components/blogPostPage/PostFooter';
 import PostHeader from '../components/blogPostPage/PostHeader';
 import ShareButtons from '../components/blogPostPage/ShareButtons';
@@ -38,6 +38,18 @@ export const query = graphql`
         ... on PostGroupImageSection {
           id
           slice_type: sliceType
+          primary
+          groupImageCaption
+          groupImage1 {
+            childImageSharp {
+              gatsbyImageData
+            }
+          }
+          groupImage2 {
+            childImageSharp {
+              gatsbyImageData
+            }
+          }
         }
         ... on PostQuoteSection {
           id

--- a/about.daangn.com/src/templates/BlogPostPage.tsx
+++ b/about.daangn.com/src/templates/BlogPostPage.tsx
@@ -100,7 +100,10 @@ const BlogPostPage: React.FC<BlogPostPageProps> = ({ data }) => {
         <Container>
           <PostHeader postHeader={data.post} />
           {data.post.thumbnailImage.childImageSharp?.gatsbyImageData && (
-            <ThumbnailImage image={data.post.thumbnailImage.childImageSharp?.gatsbyImageData} alt={''} />
+            <ThumbnailImage
+              image={data.post.thumbnailImage.childImageSharp?.gatsbyImageData}
+              alt={`${data.post.title}_포스트썸네일`}
+            />
           )}
           <PostBody>
             <ContentContainer>
@@ -128,7 +131,7 @@ const BlogPostPage: React.FC<BlogPostPageProps> = ({ data }) => {
     )
   );
 };
-BlogPostPage
+BlogPostPage;
 type BlogPostPageHeadProps = HeadProps<GatsbyTypes.BlogPostPageQuery>;
 
 export const Head: React.FC<BlogPostPageHeadProps> = ({ data, location }) => {
@@ -137,12 +140,7 @@ export const Head: React.FC<BlogPostPageHeadProps> = ({ data, location }) => {
   const metaImage = data.post?.ogImage.childImageSharp?.fixed;
 
   return (
-    <HeadSeo
-      location={location}
-      root
-      title={title}
-      description={description}
-    >
+    <HeadSeo location={location} root title={title} description={description}>
       {(props) => [
         <OpenGraph
           og={{

--- a/about.daangn.com/src/templates/BlogPostPage.tsx
+++ b/about.daangn.com/src/templates/BlogPostPage.tsx
@@ -7,6 +7,10 @@ import * as React from 'react';
 
 import Author from '../components/blogPostPage/Author';
 import PostBodyRichText from '../components/blogPostPage/PostBodyRichText';
+import PostBodyGroupImage from '../components/blogPostPage/PostBodyGroupImage';
+import PostBodyQuote from '../components/blogPostPage/PostBodyQuote';
+import PostBodyVerticalQuote from '../components/blogPostPage/PostBodyVerticalQuote';
+import PostBodyCtaButton from '../components/blogPostPage/PostBodyCtaButton';
 import PostFooter from '../components/blogPostPage/PostFooter';
 import PostHeader from '../components/blogPostPage/PostHeader';
 import ShareButtons from '../components/blogPostPage/ShareButtons';
@@ -26,11 +30,30 @@ export const query = graphql`
       ...Author_post
       ...RelatedPost_post
       body {
-        primary
-        content
-        id
-        items
-        slice_type: sliceType
+        ... on PostRichTextSection {
+          id
+          primary
+          slice_type: sliceType
+        }
+        ... on PostGroupImageSection {
+          id
+          slice_type: sliceType
+        }
+        ... on PostQuoteSection {
+          id
+          primary
+          slice_type: sliceType
+        }
+        ... on PostVerticalQuoteSection {
+          id
+          primary
+          slice_type: sliceType
+        }
+        ... on PostCtaButtonSection {
+          id
+          primary
+          slice_type: sliceType
+        }
       }
     }
   }
@@ -56,6 +79,10 @@ const BlogPostPage: React.FC<BlogPostPageProps> = ({ data }) => {
                 slices={data.post.body as any[]}
                 components={{
                   rich_text_section: PostBodyRichText,
+                  group_image_section: PostBodyGroupImage,
+                  quote_section: PostBodyQuote,
+                  vertical_quote_section: PostBodyVerticalQuote,
+                  cta_button: PostBodyCtaButton,
                 }}
               />
             </ContentContainer>
@@ -137,6 +164,8 @@ const Modal = styled('div', {
 const ContentContainer = styled('div', {
   display: 'flex',
   flexFlow: 'row nowrap',
+  flexDirection: 'column',
+  alignItems: 'center',
   height: 'auto',
   overflow: 'auto',
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,6 +4775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prismjs@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@types/prismjs@npm:1.26.0"
+  checksum: cd5e7a6214c1f4213ec512a5fcf6d8fe37a56b813fc57ac95b5ff5ee074742bfdbd2f2730d9fd985205bf4586728e09baa97023f739e5aa1c9735a7c1ecbd11a
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
@@ -5236,6 +5243,7 @@ __metadata:
     "@seed-design/design-token": alpha
     "@types/dotenv-safe": 8.1.2
     "@types/node": 18.15.11
+    "@types/prismjs": 1.26.0
     "@types/react": 18.0.31
     "@types/react-dom": 18.0.11
     babel-preset-gatsby-package: 3.8.0


### PR DESCRIPTION
- 포스트 본문 영역 구성할 수 있는 slice 추가
- 컴포넌트 구현
- 커스텀 스키마 구성
  - Rich Text Section: 포스트 본문 영역
  - CTA Button: 포스트 하단에 나타나는 CTA 버튼 영역
  - Group Image Section : 2개의 그룹 이미지 영역
  - Quote Section : 큰따옴표로 감싼 인용구 영역
  - Vertical Quote Section : 세로바 형태의 인용구 영역