### PR TITLE
feat(gatsby-transformer-post): extend post node

### DIFF
--- a/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-config.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-post/gatsby/gatsby-config.ts
@@ -1,0 +1,14 @@
+import type { GatsbyConfig } from 'gatsby';
+
+const config: GatsbyConfig = {
+  plugins: [
+    {
+      resolve: 'gatsby-source-note-com',
+      options: {
+        creator: 'jp_karrot',
+      },
+    },
+  ],
+};
+
+export default config;

--- a/_packages/@karrotmarket/gatsby-transformer-post/gatsby/types.ts
+++ b/_packages/@karrotmarket/gatsby-transformer-post/gatsby/types.ts
@@ -10,6 +10,7 @@ import {
   type SliceZone,
   type TitleField,
 } from '@prismicio/types';
+import { type NoteContentNode } from 'gatsby-source-note-com/types';
 import { type Node } from 'gatsby';
 
 type PrismicSourceNode = Node & {
@@ -126,4 +127,15 @@ export type PrismicMemberProfileNode = PrismicSourceNode &
 
 export function isPrismicMemberProfile(node: Node): node is PrismicMemberProfileNode {
   return node.internal.type === 'PrismicMemberProfile';
+}
+
+export function isNoteContentNode(node: Node): node is NoteContentNode {
+  return node.internal.type === 'NoteContent';
+}
+
+export type PostNode = PrismicPostNode | NoteContentNode;
+
+// When building a schema, check if the post node is a Prismic post
+export function isPrismicPost(node: PostNode): node is PrismicPostNode {
+  return node.prismicId !== undefined;
 }

--- a/_packages/@karrotmarket/gatsby-transformer-post/package.json
+++ b/_packages/@karrotmarket/gatsby-transformer-post/package.json
@@ -22,6 +22,7 @@
     "typescript": "5.0.3"
   },
   "dependencies": {
-    "gatsby-source-filesystem": "5.8.0"
+    "gatsby-source-filesystem": "5.8.0",
+    "gatsby-source-note-com": "0.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3004,6 +3004,7 @@ __metadata:
     concurrently: 7.6.0
     gatsby: 5.8.0
     gatsby-source-filesystem: 5.8.0
+    gatsby-source-note-com: 0.0.5
     typescript: 5.0.3
   peerDependencies:
     gatsby: ^4.19.0 || ^5.0.0


### PR DESCRIPTION
~[https://github.com/daangn/websites/pull/924](https://github.com/daangn/websites/pull/924)~

`Post` 노드를 확장가능하게 표현해요.
기존 prismic에만 종속되어 있던 `Post` 노드를 Note, 추후 medium 등까지 담을 수 있게해요.
jp 노트 블로그 나간거에서 기존 blog 컴포넌트들을 쓰도록 변경이 필요한데, 카테고리나 UI자체가 다른 부분이 있기 때문에 나중에 한꺼번에 변경해도 될 것 같아요~