### PR TITLE
refactor: Replace typeof window !== 'undefined' with isBrowser 

### DIFF
--- a/_packages/@karrotmarket/gatsby-theme-website-team/src/layouts/JobPostLayout.tsx
+++ b/_packages/@karrotmarket/gatsby-theme-website-team/src/layouts/JobPostLayout.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import logoPath from '../assets/logo.png';
 import _PageTitle from '../components/PageTitle';
-import { lookup } from '../utils/common';
+import { isBrowser, lookup } from '../utils/common';
 
 import JobPostingJsonLd from './jobPostLayout/JobPostingJsonLd';
 import generateProperties from './jobPostLayout/generateProperties';
@@ -226,7 +226,7 @@ const JobPostLayout: React.FC<JobPostLayoutProps> = ({
                   <TabLink
                     to={viewPath}
                     active={currentPath === viewPath}
-                    state={{ y: typeof window !== 'undefined' && window.scrollY }}
+                    state={{ y: isBrowser && window.scrollY }}
                   >
                     {messages.job_post_layout__tab_view}
                   </TabLink>
@@ -238,7 +238,7 @@ const JobPostLayout: React.FC<JobPostLayoutProps> = ({
                   <TabLink
                     to={applyPath}
                     active={currentPath === applyPath}
-                    state={{ y: typeof window !== 'undefined' && window.scrollY }}
+                    state={{ y: isBrowser && window.scrollY }}
                   >
                     {messages.job_post_layout__tab_apply}
                   </TabLink>

--- a/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/common.ts
+++ b/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/common.ts
@@ -17,3 +17,5 @@ export function isCanonicalUrl(url: string): boolean {
 
   return false;
 }
+
+export const isBrowser = typeof window !== 'undefined'

--- a/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/usePreferColorScheme.ts
+++ b/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/usePreferColorScheme.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isBrowser } from './common';
 
 export function usePrefersColorScheme(): 'light' | 'dark' {
   const [getSnapshot, getServerSnapshot, subscribe] = React.useMemo(() => {
@@ -18,7 +19,7 @@ export function usePrefersColorScheme(): 'light' | 'dark' {
 
   return React.useSyncExternalStore(
     subscribe,
-    typeof window !== 'undefined' ? getSnapshot : getServerSnapshot,
+    isBrowser ? getSnapshot : getServerSnapshot,
     getServerSnapshot,
   );
 }

--- a/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/useURLSearchParams.ts
+++ b/_packages/@karrotmarket/gatsby-theme-website-team/src/utils/useURLSearchParams.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isBrowser } from './common';
 
 export function useURLSearchParams(): URLSearchParams {
   const [getSnapshot, getServerSnapshot, subscribe] = React.useMemo(() => {
@@ -16,7 +17,7 @@ export function useURLSearchParams(): URLSearchParams {
 
   const search = React.useSyncExternalStore(
     subscribe,
-    typeof window !== 'undefined' ? getSnapshot : getServerSnapshot,
+    isBrowser ? getSnapshot : getServerSnapshot,
     getServerSnapshot,
   );
 


### PR DESCRIPTION
여러 곳에서 `typeof window !== 'undefined'`가 중복으로 사용되고 있어서 `utils/common`파일에 `isBrowser`로 단일화 시켰습니다!