### PR TITLE
refactor: Change hex-color to design token

### DIFF
--- a/about.daangn.com/gatsby-config.ts
+++ b/about.daangn.com/gatsby-config.ts
@@ -1,5 +1,6 @@
 import type { GatsbyConfig } from 'gatsby';
 
+import { vars } from '@seed-design/design-token';
 import 'dotenv/config';
 
 const siteMetadata = {
@@ -40,8 +41,8 @@ const config: GatsbyConfig = {
         name: siteMetadata.siteName,
         short_name: siteMetadata.siteName,
         start_url: '/',
-        theme_color: '#ff7e36',
-        background_color: '#ffffff',
+        theme_color: vars.$scale.color.carrot500,
+        background_color: vars.$scale.color.gray00,
         display: 'minimal-ui',
         icon: 'src/assets/favicon.svg',
       },

--- a/careers.jp.karrotmarket.com/gatsby-config.ts
+++ b/careers.jp.karrotmarket.com/gatsby-config.ts
@@ -1,5 +1,6 @@
 import type { GatsbyConfig } from 'gatsby';
 
+import { vars } from '@seed-design/design-token';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -28,8 +29,8 @@ const config: GatsbyConfig = {
         name: siteMetadata.siteName,
         short_name: siteMetadata.siteName,
         start_url: '/',
-        theme_color: '#ff7e36',
-        background_color: '#ffffff',
+        theme_color: vars.$scale.color.carrot500,
+        background_color: vars.$scale.color.gray00,
         display: 'minimal-ui',
         icon: 'src/assets/favicon.svg',
       },


### PR DESCRIPTION
기존에 hex값으로 되어 있는 부분을 당근 `@seed-design/design-token`에서 값을 불러오는 것으로 변경했습니다. 

다만, `theme_color: '#ff7e36'` 값은 라이브러리 내 [/archive 디렉토리](https://github.com/daangn/seed-design/blob/d2bd0bd65bb2d031e6adb4a869d21112320162bf/packages/archive/design-token/src/colors/index.ts#L23)에 있어서 옛날에 사용되던 값인걸로 보여지는데요. 혹시 변경이 필요하다면 말씀부탁드리겠습니다!

그리고 `background_color: vars.$scale.color.gray00`는 라이브러리 내 [이곳](https://github.com/daangn/seed-design/blob/d2bd0bd65bb2d031e6adb4a869d21112320162bf/packages/stylesheet/global.css#L178)을 참조했습니다.

### AS-IS
```ts
theme_color: '#ff7e36',
background_color: '#ffffff',
```

### TO-BE
``` ts
theme_color: vars.$scale.color.carrot500,
background_color: vars.$scale.color.gray00,
```